### PR TITLE
misc improvements

### DIFF
--- a/mpc/tests/utils/test_utils.rs
+++ b/mpc/tests/utils/test_utils.rs
@@ -318,7 +318,7 @@ pub fn spawn_receiver_tasks(
 
 static TRACING_INIT: Lazy<()> = Lazy::new(|| {
     let subscriber = FmtSubscriber::builder()
-        .with_env_filter(EnvFilter::from_default_env().add_directive("trace".parse().unwrap()))
+        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse().unwrap()))
         .pretty()
         .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -14,6 +14,8 @@ futures.workspace = true
 stoffelnet.workspace = true
 ark-std.workspace = true
 tracing.workspace = true
+once_cell = "1.21.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [dev-dependencies]
 ark-bls12-381.workspace = true


### PR DESCRIPTION
This is another PR of the same changes, but to dev this time.

- add more tests
- set default log level to info and improve net testing Previously, the default log level was debug, so there was no log level to print information that is strictly needed for debugging and would otherwise clutter up the log. This commit adds better logging for BadFakeNetwork, which is very often used and whose logs would therefore make the log unreadable. To solve this, the default log level is set to info and diagnostic logs for BadFakeNetwork use the debug log level, which can be enabled using `RUST_LOG=debug`.

        In addition, the `debug_assertion` flag is used for conditional compilation.
        It is set usually and can be deactivated with the `--release` switch.
- add doc to bad fake network