### PR TITLE
improve multiplication

### DIFF
--- a/mpc/src/honeybadger/fpmul/mod.rs
+++ b/mpc/src/honeybadger/fpmul/mod.rs
@@ -28,10 +28,8 @@ pub mod truncpr;
 pub enum RandBitError {
     #[error("incompatible treshold ({0:}) and number of parties {1:}")]
     IncompatibleNumberOfParties(usize, usize),
-    #[error("error in the secure multiplication protocol: {0:?}")]
-    MulError(#[from] MulError),
     #[error("the square multiplication was not completed successfuly")]
-    SquareMult,
+    SquareMult(#[from] MulError),
     #[error("the square is zero")]
     ZeroSquare,
     #[error("the square root does not exist")]

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -77,9 +77,12 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, sync::{Arc, atomic::{Ordering, AtomicU8}}};
 use stoffelnet::network_utils::{Network, NetworkError, ClientId, PartyId};
 use thiserror::Error;
-use tokio::sync::{
-    mpsc::{self, Receiver},
-    Mutex,
+use tokio::{
+    sync::{
+        mpsc::{self, Receiver},
+        Mutex,
+    },
+    time::Duration
 };
 use tracing::{info, warn};
 use triple_gen::triple_generation::TripleGenNode;
@@ -213,7 +216,6 @@ pub struct OutputChannels {
     pub dou_sha_channel: Arc<Mutex<Receiver<SessionId>>>,
     pub ran_dou_sha_channel: Arc<Mutex<Receiver<SessionId>>>,
     pub triple_channel: Arc<Mutex<Receiver<SessionId>>>,
-    pub mul_channel: Arc<Mutex<Receiver<SessionId>>>,
     pub rand_bit_channel: Arc<Mutex<Receiver<SessionId>>>,
     pub prand_bit_channel: Arc<Mutex<Receiver<SessionId>>>,
     pub prand_int_channel: Arc<Mutex<Receiver<SessionId>>>,
@@ -334,7 +336,6 @@ where
         let (dou_sha_sender, dou_sha_receiver) = mpsc::channel(128);
         let (ran_dou_sha_sender, ran_dou_sha_receiver) = mpsc::channel(128);
         let (triple_sender, triple_receiver) = mpsc::channel(128);
-        let (mul_sender, mul_receiver) = mpsc::channel(128);
         let (share_gen_sender, share_gen_reciever) = mpsc::channel(128);
         let (rand_bit_sender, rand_bit_receiver) = mpsc::channel(128);
         let (prand_bit_sender, prand_bit_receiver) = mpsc::channel(128);
@@ -363,7 +364,7 @@ where
 
         let triple_gen_node =
             TripleGenNode::new(id, params.n_parties, params.threshold, triple_sender)?;
-        let mul_node = Multiply::new(id, params.n_parties, params.threshold, mul_sender)?;
+        let mul_node = Multiply::new(id, params.n_parties, params.threshold)?;
         let share_gen = RanShaNode::new(
             id,
             params.n_parties,
@@ -402,7 +403,6 @@ where
                 dou_sha_channel: Arc::new(Mutex::new(dou_sha_receiver)),
                 ran_dou_sha_channel: Arc::new(Mutex::new(ran_dou_sha_receiver)),
                 triple_channel: Arc::new(Mutex::new(triple_receiver)),
-                mul_channel: Arc::new(Mutex::new(mul_receiver)),
                 rand_bit_channel: Arc::new(Mutex::new(rand_bit_receiver)),
                 prand_bit_channel: Arc::new(Mutex::new(prand_bit_receiver)),
                 prand_int_channel: Arc::new(Mutex::new(prand_int_receiver)),
@@ -446,17 +446,7 @@ where
             .init(session_id, x, y, beaver_triples, network)
             .await?;
 
-        let mut rx = self.outputchannels.mul_channel.lock().await;
-        while let Some(id) = rx.recv().await {
-            if id == session_id {
-                let mul_store = self.operations.mul.mult_storage.lock().await;
-                if let Some(mul_lock) = mul_store.get(&id) {
-                    let store = mul_lock.lock().await;
-                    return Ok(store.protocol_output.clone());
-                }
-            }
-        }
-        Err(HoneyBadgerError::ChannelClosed)
+        self.operations.mul.wait_for_result(session_id, Duration::MAX).await.map_err(HoneyBadgerError::from)
     }
 
     async fn process(&mut self, raw_msg: Vec<u8>, net: Arc<N>) -> Result<(), Self::Error> {

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -3,7 +3,7 @@ use crate::{
     honeybadger::{
         batch_recon::batch_recon::BatchReconNode,
         mul::{
-            concat_sorted, MulError, MultMessage, MultProtocolState, MultStorage,
+            concat_sorted, MulError, InterpolateError, MultMessage, MultProtocolState, MultStorage,
             ReconstructionMessage,
         },
         robust_interpolate::robust_interpolate::{Robust, RobustShare},
@@ -20,16 +20,101 @@ use std::{
     sync::Arc,
 };
 use stoffelnet::network_utils::{Network, PartyId};
-use tokio::sync::{mpsc::Sender, Mutex};
-use tracing::info;
+use tokio::sync::Mutex;
+use tokio::time::{timeout, Duration};
+use tracing::{info, warn, error};
+
+/// Secret multiplication is explained in Section 2.2 of the paper.
+/// Assume that we want to multiply two t-shares x and y. We take a Beaver triple
+/// (a, b, a*b) and 
+/// 
+/// 1. calculate a - x and b - y and open these values
+/// 2. calculate x*y = a*b - (a - x)(b - y) - (a - x)y - (b - y)x; a - x and b - y have been
+///    opened, a*b is part of the Beaver triple and x and y are known shares
+///
+/// Opening in step (1) happens using batch reconstruction and also RBC.
+/// The former is used for chunks of t + 1 shares and the remainder of these, if any, is
+/// reconstructed using the latter.
+/// For example, if `n = 10` and `t = 3`, then 10 multiplications would be performed by running
+/// batch reconstruction four times: on two chunks each of size 4 for `a - x` and `b - y`,
+/// respectively. In addition, each node would run RBC once for the remaining values, which are two
+/// values of `a - x` and `b - y`, respectively. While batch reconstruction takes care of the
+/// distribution of the shares and their reconstruction at the same time, the nodes need to
+/// manually reconstruct the shares received via RBC.
+///
+/// The storage per multiplication is accessed by `Multiply::init` and `open_mult_handler` and is protected by
+/// a mutex.
+
+// requires that Multiply::init has been called before and all chunks and shares via RBC have been
+// received
+fn finalize_mul<F: FftField>(storage: &MultStorage<F>) -> Result<Vec<RobustShare<F>>, MulError> {
+    assert!(storage.openings.is_some());    // always ensured by the caller
+
+    let openings = storage.openings.as_ref().unwrap();
+
+    let mut concatenated_mult1: Vec<F> = concat_sorted(&storage.output_open_mult1);
+    concatenated_mult1.extend(openings.0.clone());
+
+    let mut concatenated_mult2: Vec<F> = concat_sorted(&storage.output_open_mult2);
+    concatenated_mult2.extend(openings.1.clone());
+
+    let mut shares_mult = Vec::with_capacity(storage.share_mult_from_triple.len());
+    for (triple_mult, input_a, input_b, subtraction_a, subtraction_b) in izip!(
+        &storage.share_mult_from_triple,
+        &storage.inputs.0,
+        &storage.inputs.1,
+        concatenated_mult1,
+        concatenated_mult2,
+    ) {
+        //(a−x)(b−y)
+        let mult_subs = subtraction_a * subtraction_b;
+        //(a−x)[y]_t
+        let mult_sub_a_y = input_b.clone().mul(subtraction_a)?;
+        //(b−y)[x]_t
+        let mult_sub_b_x = input_a.clone().mul(subtraction_b)?;
+        //[xy]_t
+        let share = triple_mult.clone().sub(mult_subs)?;
+        let share2: ShamirShare<F, 1, Robust> = (share - mult_sub_a_y)?;
+        let share3 = (share2 - mult_sub_b_x)?;
+        shares_mult.push(share3);
+    }
+
+    Ok(shares_mult)
+}
+
+fn reconstruct_rbc<F: FftField>(received_shares: &HashMap<PartyId, (Vec<RobustShare<F>>, Vec<RobustShare<F>>)>, share_len: usize, n: usize) -> Result<(Vec<F>, Vec<F>), InterpolateError> {
+    let mut a_sub_x: Vec<F> = Vec::new();
+    let mut b_sub_y: Vec<F> = Vec::new();
+    let mut a_shares = vec![vec![]; share_len];
+    let mut b_shares = vec![vec![]; share_len];
+
+    for (id, (a, b)) in received_shares.iter() {
+        if a.len() != share_len || b.len() != share_len {
+            warn!("Node {} did not send right number of shares to reconstruct using RBC (sent {} for a-x and {} for b-y)", id, a.len(), b.len());
+        }
+    
+        for i in 0..share_len {
+            a_shares[i].push(a[i].clone());
+            b_shares[i].push(b[i].clone());
+        }
+    }
+    for i in 0..share_len {
+        let a = RobustShare::recover_secret(&a_shares[i], n)?;
+        let b = RobustShare::recover_secret(&b_shares[i], n)?;
+    
+        a_sub_x.push(a.1);
+        b_sub_y.push(b.1);
+    }
+
+    Ok((a_sub_x, b_sub_y))
+}
 
 #[derive(Clone, Debug)]
 pub struct Multiply<F: FftField, R: RBC> {
     pub id: usize,
     pub n: usize,
-    pub threshold: usize,
+    pub t: usize,
     pub mult_storage: Arc<Mutex<HashMap<SessionId, Arc<Mutex<MultStorage<F>>>>>>,
-    pub sender_finished_mults: Sender<SessionId>,
     pub batch_recon: BatchReconNode<F>,
     pub rbc: R,
 }
@@ -39,16 +124,14 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         id: PartyId,
         n: usize,
         threshold: usize,
-        output_sender: Sender<SessionId>,
     ) -> Result<Self, MulError> {
         let batch_recon = BatchReconNode::<F>::new(id, n, threshold)?;
         let rbc = R::new(id, n, threshold, threshold + 1)?;
         Ok(Self {
             id,
             n,
-            threshold,
+            t: threshold,
             mult_storage: Arc::new(Mutex::new(HashMap::new())),
-            sender_finished_mults: output_sender,
             batch_recon,
             rbc,
         })
@@ -60,30 +143,99 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         self.rbc.clear_store().await;
     }
 
-    pub async fn init<N: Network>(
+    // 1. Take storage lock
+    // 2. Find chunks for batch reconstruction that have not been opened yet
+    // 3. Set inputs x and y, Beaver triples, number of multiplications, and disable RBC if not
+    //    needed
+    // 4. Reconstruct from RBC-sent shares if enough have been received and needed
+    // 5. Perform the multiplication and return if all openings are available
+    // 6. Otherwise, compute all local (a - x)- and (b - y)-shares
+    // 7. Release the storage lock
+    // 8. Initiate batch reconstruction for all chunks that have not been opened yet
+    // 9. Initiate RBC if needed
+    //
+    // `init` mainly serves to set the inputs and Beaver triples for multiplication and to
+    // initiate the opening of the a-x,b-y values. However, due to the asynchronous nature of the
+    // protocols and the malicious security, some or even all openings could already have been
+    // received without any contribution by one node. Therefore, `init` does not initiate the
+    // opening for all values, but only for the missing ones. Since `init` could even be called
+    // after all openings have been received, it needs to be able to perform the final multiplication
+    // itself.
+    //
+    // The lock is released before initiating batch reconstruction or RBC to avoid unforeseen delays
+    // or other synchronicity issues. While this enables a possible race condition where batches or
+    // the RBC broadcast are received right after releasing the lock and therefore batch
+    // reconstruction or RBC are initiated unnecessarily, this does no harm.
+    pub async fn init<N: Network + Send + Sync>(
         &mut self,
         session_id: SessionId,
         x: Vec<RobustShare<F>>,
         y: Vec<RobustShare<F>>,
         beaver_triples: Vec<ShamirBeaverTriple<F>>,
-        network: Arc<N>,
-    ) -> Result<(), MulError>
-    where
-        N: Network + Send + Sync,
-    {
+        network: Arc<N>
+    ) -> Result<(), MulError> {
         info!(party = self.id, "Initializing multiplication");
         if x.len() != y.len() || x.len() != beaver_triples.len() {
-            return Err(MulError::InvalidInput("Incorrect input lenght".to_string()));
+            return Err(MulError::InvalidInput("Length of x and y vectors and Beaver triples must match".to_string()));
         }
+
+        let no_of_mul = x.len();
+        let no_of_batch = no_of_mul / (self.t + 1);
+        let share_len = x.len() % (self.t + 1);
+
+        // 1.
         let storage_bind = self.get_or_create_mult_storage(session_id).await;
         let mut storage = storage_bind.lock().await;
+
+        // 2.
+        let have_batch_recon1: Vec<_> = (0..no_of_batch)
+            .map(|i| storage.output_open_mult1.contains_key(&((2 * i) as u8)))
+            .collect();
+        let have_batch_recon2: Vec<_> = (0..no_of_batch)
+            .map(|i| storage.output_open_mult2.contains_key(&((2 * i + 1) as u8)))
+            .collect();
+
+        // 3.
+        storage.no_of_mul = Some(no_of_mul);
         storage.inputs = (x.clone(), y.clone());
         storage.share_mult_from_triple = beaver_triples
             .iter()
             .map(|triple| triple.mult.clone())
             .collect();
+        if share_len == 0 {
+            storage.openings = Some((vec![], vec![]));
+        }
 
-        // Compute a - x and b - y.
+        // 4.
+        if storage.received_shares.len() >= 2 * self.t + 1 && storage.openings.is_none() {
+            // `share_len != 0`, since some honest nodes have sent us their shares
+            info!("Received enough messages with shares to try reconstruction using RBC");
+
+            match reconstruct_rbc(&storage.received_shares, share_len, self.n) {
+                Ok(openings) => {
+                    info!("Reconstruction succeeded");
+                    storage.openings = Some(openings);
+                }
+                Err(e) => error!("Reconstruction in init failed: {e}")  // could fail if shares corrupt
+            };
+        }
+
+        // 5.
+        if have_batch_recon1.iter().all(|b| *b) && have_batch_recon2.iter().all(|b| *b) && storage.openings.is_some() {
+            let shares_mult = finalize_mul(&storage)?;
+    
+            // never None because checked at the beginning
+            let taken_output_sender = storage.output_sender.take().unwrap();
+    
+            taken_output_sender.send(shares_mult).map_err(|_| MulError::SendError(session_id))?;
+            storage.protocol_state = MultProtocolState::Finished;
+
+            info!("Multiplication completed at node {}", self.id);
+
+            return Ok(());
+        }
+
+        // 6.
         let a_sub_x = x
             .iter()
             .zip(beaver_triples.iter())
@@ -95,41 +247,50 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
             .map(|(y, triple)| triple.b.clone() - y.clone())
             .collect::<Result<Vec<RobustShare<F>>, ShareError>>()?;
 
-        let t = self.threshold;
-        let split_at = a_sub_x.len() - (a_sub_x.len() % (t + 1));
+        let split_at = a_sub_x.len() - share_len;
         let (a_full, remaining_a) = a_sub_x.split_at(split_at);
         let (b_full, remaining_b) = b_sub_y.split_at(split_at);
-        storage.no_of_mul = Some(a_sub_x.len());
+
+        let need_rbc = storage.openings.is_none();
+
+        // 7.
         drop(storage);
 
-        for (i, (chunk_a, chunk_b)) in a_full.chunks(t + 1).zip(b_full.chunks(t + 1)).enumerate() {
-            let session_id1 = SessionId::new(
-                session_id.calling_protocol().unwrap(),
-                session_id.exec_id(),
-                1,
-                (2 * i) as u8,
-                session_id.instance_id(),
-            );
-            let session_id2 = SessionId::new(
-                session_id.calling_protocol().unwrap(),
-                session_id.exec_id(),
-                1,
-                (2 * i + 1) as u8,
-                session_id.instance_id(),
-            );
+        // 8.
+        // initiate batch reconstruction for those chunks that need it
+        for (i, (chunk_a, chunk_b)) in a_full.chunks(self.t + 1).zip(b_full.chunks(self.t + 1)).enumerate() {
+            if !have_batch_recon1[i] {
+                let session_id1 = SessionId::new(
+                    session_id.calling_protocol().unwrap(),
+                    session_id.exec_id(),
+                    1,
+                    (2 * i) as u8,
+                    session_id.instance_id(),
+                );
+                // Execute batch reconstruction for a-x values
+                self.batch_recon
+                    .init_batch_reconstruct(chunk_a, session_id1, Arc::clone(&network))
+                    .await?;
+            }
 
-            // Executes the batch reconstruction to reconstruct the messages.
-            self.batch_recon
-                .init_batch_reconstruct(&chunk_a, session_id1, Arc::clone(&network))
-                .await?;
-
-            self.batch_recon
-                .init_batch_reconstruct(&chunk_b, session_id2, Arc::clone(&network))
-                .await?;
+            if !have_batch_recon2[i] {
+                let session_id2 = SessionId::new(
+                    session_id.calling_protocol().unwrap(),
+                    session_id.exec_id(),
+                    1,
+                    (2 * i + 1) as u8,
+                    session_id.instance_id(),
+                );
+                // Execute batch reconstruction for b-y values
+                self.batch_recon
+                    .init_batch_reconstruct(chunk_b, session_id2, Arc::clone(&network))
+                    .await?;
+            }
         }
 
-        //Reconstruct < t+1 values
-        if remaining_a.len() > 0 && remaining_b.len() > 0 {
+        // 9.
+        if need_rbc {
+            // Reconstruct < t+1 values
             let reconst_message =
                 ReconstructionMessage::new(remaining_a.to_vec(), remaining_b.to_vec());
             let mut bytes_rec_message = Vec::new();
@@ -151,13 +312,25 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
                 .init(bytes_wrapped, sessionid, Arc::clone(&network))
                 .await?;
         }
+
         Ok(())
     }
 
+    // 1. Take storage lock
+    // 2. Store the a-x, b-y values opened through batch reconstruction in the appropriate slot
+    // 3. Get the number of multiplications or return if `init` has not been called yet
+    // 4. Reconstruct from RBC-sent shares if enough have been received and needed
+    // 5. Return if not all openings are available
+    // 5. Perform the multiplication and return if all openings are available
+    // 6. Otherwise, compute all local (a - x)- and (b - y)-shares
+    //
+    // `open_mult_handler` mainly serves to receive opened values from batch reconstruction
+    // or shares from RBC, from which openings will be manually reconstructed.
+    // If `init` has been called, then it can also try to perform the multiplication.
     pub async fn open_mult_handler(
         &self,
         msg: MultMessage,
-    ) -> Result<Option<Vec<RobustShare<F>>>, MulError> {
+    ) -> Result<(), MulError> {
         let session_id = SessionId::new(
             msg.session_id.calling_protocol().unwrap(),
             msg.session_id.exec_id(),
@@ -166,36 +339,35 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
             msg.session_id.instance_id(),
         );
 
+        // 1.
         let storage_bind = self.get_or_create_mult_storage(session_id).await;
         let mut storage = storage_bind.lock().await;
 
-        let mul_len = storage.no_of_mul.ok_or(MulError::InvalidInput(format!(
-            "No. of multiplications not set for node {}",
-            self.id
-        )))?;
-        let share_len = mul_len % (self.threshold + 1);
+        if storage.protocol_state == MultProtocolState::Finished {
+            return Ok(());
+        }
 
-        // Store the values in the appropriate slot
+        // 2.
         if msg.session_id.sub_id() == 1 {
             let open: Vec<F> =
                 CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
             let round_id = msg.session_id.round_id();
             let (target_map, label) = if round_id % 2 == 0 {
-                (&mut storage.output_open_mult1, "first")
+                (&mut storage.output_open_mult1, "a-x")
             } else {
-                (&mut storage.output_open_mult2, "second")
+                (&mut storage.output_open_mult2, "b-y")
             };
 
             if target_map.contains_key(&round_id) {
                 return Err(MulError::Duplicate(format!(
-                    "Already received from {}",
-                    msg.sender
+                    "Received duplicate of round {}",
+                    round_id
                 )));
             }
 
             info!(
                 self_id = self.id,
-                "Received {} open message for session_id: {:?} and round {:?}",
+                "Received opened {} values for session_id: {:?} and round {:?}",
                 label,
                 session_id,
                 round_id
@@ -205,92 +377,61 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         } else if msg.session_id.sub_id() == 2 {
             info!(
                 self_id = self.id,
-                "Received shares for reconstruction for session_id: {:?}", session_id
+                "Received shares for reconstruction using RBC for session_id: {:?}", session_id
             );
             if storage.received_shares.contains_key(&msg.sender) {
                 return Err(MulError::Duplicate(format!(
-                    "Already received from {}",
+                    "Already received shares for reconstruction using RBC from {}",
                     msg.sender
                 )));
             }
+
             let open_message: ReconstructionMessage<F> =
                 CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
 
-            if open_message.a_sub_x.len() != share_len || open_message.b_sub_x.len() != share_len {
-                return Err(MulError::InvalidInput(
-                    "Not enough shares to reconstruct the opening".to_string(),
-                ));
-            }
             storage
                 .received_shares
-                .insert(msg.sender, (open_message.a_sub_x, open_message.b_sub_x));
+                .insert(msg.sender, (open_message.a_sub_x, open_message.b_sub_y));
         }
 
-        let mut a_sub_x: Vec<F> = Vec::new();
-        let mut b_sub_x: Vec<F> = Vec::new();
-        if share_len != 0 {
-            if storage.received_shares.len() >= 2 * self.threshold + 1 {
-                info!("Received enough shares to reconstruct");
-                let mut a_shares = vec![vec![]; share_len];
-                let mut b_shares = vec![vec![]; share_len];
-                for (_, (a, b)) in storage.received_shares.iter() {
-                    for i in 0..share_len {
-                        a_shares[i].push(a[i].clone());
-                        b_shares[i].push(b[i].clone());
-                    }
-                }
-                for i in 0..share_len {
-                    let a = RobustShare::recover_secret(&a_shares[i], self.n)?;
-                    let b = RobustShare::recover_secret(&b_shares[i], self.n)?;
+        // 3.
+        let no_of_mul = storage.no_of_mul.ok_or(MulError::InvalidInput(format!(
+            "No. of multiplications not set for node (init not called yet) {}",
+            self.id
+        )))?;
+        let no_of_batch = no_of_mul / (self.t + 1);
+        let share_len = no_of_mul % (self.t + 1);
 
-                    a_sub_x.push(a.1);
-                    b_sub_x.push(b.1);
-                }
-            }
+        // 4.
+        if storage.received_shares.len() >= 2 * self.t + 1 && storage.openings.is_none() {
+            // `share_len != 0`, since some honest nodes have sent us their shares
+            info!("Received enough messages with shares to try reconstruction using RBC");
+            let openings = reconstruct_rbc(&storage.received_shares, share_len, self.n)?;
+
+            info!("Reconstruction succeeded");
+            storage.openings = Some(openings);
         }
 
-        let no_of_batch = mul_len / (self.threshold + 1);
+        // 5.
         if storage.output_open_mult1.len() != no_of_batch
             || storage.output_open_mult2.len() != no_of_batch
-            || a_sub_x.len() != share_len
-            || b_sub_x.len() != share_len
+            || storage.openings.is_none()
         {
             return Err(MulError::WaitForOk);
         }
 
-        let mut concatenated_mult1: Vec<F> = concat_sorted(&storage.output_open_mult1);
-        concatenated_mult1.extend(a_sub_x);
+        // 6.
+        let shares_mult = finalize_mul(&storage)?;
 
-        let mut concatenated_mult2: Vec<F> = concat_sorted(&storage.output_open_mult2);
-        concatenated_mult2.extend(b_sub_x);
+        // never None because checked at the beginning
+        let taken_output_sender = storage.output_sender.take().unwrap();
 
-        let mut shares_mult = Vec::with_capacity(storage.share_mult_from_triple.len());
-        for (triple_mult, input_a, input_b, subtraction_a, subtraction_b) in izip!(
-            &storage.share_mult_from_triple,
-            &storage.inputs.0,
-            &storage.inputs.1,
-            concatenated_mult1,
-            concatenated_mult2,
-        ) {
-            //(a−x)(b−y)
-            let mult_subs = subtraction_a * subtraction_b;
-            //(a−x)[y]_t
-            let mult_sub_a_y = input_b.clone().mul(subtraction_a.clone())?;
-            //(b−y)[x]_t
-            let mult_sub_b_x = input_a.clone().mul(subtraction_b.clone())?;
-            //[xy]_t
-            let share = triple_mult.clone().sub(mult_subs)?;
-            let share2: ShamirShare<F, 1, Robust> = (share - mult_sub_a_y)?;
-            let share3 = (share2 - mult_sub_b_x)?;
-            shares_mult.push(share3);
-        }
-
-        storage.protocol_output = shares_mult.clone();
+        taken_output_sender.send(shares_mult).map_err(|_| MulError::SendError(session_id))?;
         storage.protocol_state = MultProtocolState::Finished;
-        info!(id = self.id, "Multiplication finished",);
-        self.sender_finished_mults.send(session_id).await?;
 
-        Ok(Some(shares_mult))
+        info!("Multiplication completed at node {}", self.id);
+
+        Ok(())
     }
 
     pub async fn process(&mut self, message: MultMessage) -> Result<(), MulError> {
@@ -298,7 +439,7 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         Ok(())
     }
 
-    async fn get_or_create_mult_storage(
+    pub async fn get_or_create_mult_storage(
         &self,
         session_id: SessionId,
     ) -> Arc<Mutex<MultStorage<F>>> {
@@ -307,5 +448,462 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(MultStorage::empty())))
             .clone()
+    }
+
+    pub async fn wait_for_result(&self, session_id: SessionId, duration: Duration) -> Result<Vec<RobustShare<F>>, MulError> {
+        // scoped because self.mult_storage and storage locks must not be held anymore
+        // when receiving afterwards
+        let output_receiver = {
+            let mult_storage = self.mult_storage.lock().await;
+            let storage_bind = match mult_storage.get(&session_id) {
+                Some(value) => value,
+                None => return Err(MulError::NoSuchSessionId(session_id))
+            };
+            let mut storage = storage_bind.lock().await;
+
+            storage.output_receiver
+                   .take()
+                   .ok_or(MulError::ResultAlreadyReceived(session_id))?
+        };
+
+        match timeout(duration, output_receiver).await {
+            Err(_) => {
+                Err(MulError::Timeout(session_id))
+            }
+            Ok(Err(_)) => {
+                Err(MulError::ReceiveError(session_id))
+            }
+            Ok(Ok(mul_shares)) => {
+                Ok(mul_shares)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use ark_std::test_rng;
+    use ark_bls12_381::Fr;
+    use ark_ff::UniformRand;
+    use crate::{
+        common::{rbc::rbc::Avid, SecretSharingScheme},
+        honeybadger::{
+            ProtocolType,
+            RbcError,
+            robust_interpolate::robust_interpolate::RobustShare,
+            WrappedMessage,
+        }
+    };
+    use tokio::time::{sleep, Duration};
+    use stoffelmpc_network::fake_network::{FakeNetwork, FakeNetworkConfig};
+    use rand::{thread_rng, prelude::SliceRandom};
+
+    async fn construct_input_mul(
+        n_parties: usize,
+        n_triples: usize,
+        threshold: usize,
+    ) -> ((Vec<Fr>, Vec<Fr>, Vec<Fr>), Vec<Vec<ShamirBeaverTriple<Fr>>>) {
+        let mut rng = test_rng();
+        let mut secrets_a = Vec::new();
+        let mut secrets_b = Vec::new();
+        let mut secrets_c = Vec::new();
+        let mut per_party_triples: Vec<Vec<ShamirBeaverTriple<Fr>>> = vec![Vec::new(); n_parties];
+    
+        for _i in 0..n_triples {
+            // sample secrets a,b
+            let a_secret = Fr::rand(&mut rng);
+            let b_secret = Fr::rand(&mut rng);
+            let c_secret = a_secret * b_secret;
+    
+            // make robust shares for each secret (length == n_parties)
+            let shares_a = RobustShare::compute_shares(a_secret, n_parties, threshold, None, &mut rng)
+                .expect("share a creation failed");
+            let shares_b = RobustShare::compute_shares(b_secret, n_parties, threshold, None, &mut rng)
+                .expect("share b creation failed");
+            let shares_c = RobustShare::compute_shares(c_secret, n_parties, threshold, None, &mut rng)
+                .expect("share c creation failed");
+    
+            // push the secrets to the vectors
+            secrets_a.push(a_secret);
+            secrets_b.push(b_secret);
+            secrets_c.push(c_secret);
+    
+            // For each party, create their per-party ShamirBeaverTriple and push it
+            for pid in 0..n_parties {
+                let triple = ShamirBeaverTriple {
+                    a: shares_a[pid].clone(),
+                    b: shares_b[pid].clone(),
+                    mult: shares_c[pid].clone(),
+                };
+                per_party_triples[pid].push(triple);
+            }
+        }
+        ((secrets_a, secrets_b, secrets_c), per_party_triples)
+    }
+
+    /// `2t+1` nodes send random shares to the client, which reconstructs the random value and
+    /// broadcasts the masked input. Some node, which is not one of the `2t+1` has not sent its
+    /// random share and receives the masked input before even having called `InputServer::init`.
+    #[tokio::test]
+    async fn test_init_last() {
+        let n = 10;
+        let t = 3;
+        let node_id = 0;
+        let no_of_mul = 10;
+        let session_id = SessionId::new(ProtocolType::Mul, 123, 0, 0, 111);
+        let mut rng = test_rng();
+    
+        // 1. Generate Beaver triples
+        let ((secrets_a, secrets_b, _), beaver_triples) = construct_input_mul(n, no_of_mul, t).await;
+        let mult_from_triple: Vec<_> = beaver_triples[node_id]
+            .iter()
+            .map(|triple| triple.mult.clone())
+            .collect();
+    
+        // 2. Prepare inputs for multiplication
+        let mut x_values = Vec::new();
+        let mut y_values = Vec::new();
+        let mut x_inputs_per_node = vec![Vec::new(); n];
+        let mut y_inputs_per_node = vec![Vec::new(); n];
+    
+        for _i in 0..no_of_mul {
+            let x_value = Fr::rand(&mut rng);
+            x_values.push(x_value);
+            let y_value = Fr::rand(&mut rng);
+            y_values.push(y_value);
+    
+            let shares_x = RobustShare::compute_shares(x_value, n, t, None, &mut rng).unwrap();
+            let shares_y = RobustShare::compute_shares(y_value, n, t, None, &mut rng).unwrap();
+    
+            for p in 0..n {
+                x_inputs_per_node[p].push(shares_x[p].clone());
+                y_inputs_per_node[p].push(shares_y[p].clone());
+            }
+        }
+    
+        // 3. Generate correct openings and shares
+        let correct_a_sub_x = secrets_a.clone().iter().zip(x_values.clone()).map(|(a, x)| *a - x).collect::<Vec<_>>();
+        let correct_b_sub_y = secrets_b.clone().iter().zip(y_values.clone()).map(|(b, y)| *b - y).collect::<Vec<_>>();
+    
+        let mut correct_shares = Vec::with_capacity(mult_from_triple.len());
+        for (triple_mult, input_a, input_b, subtraction_a, subtraction_b) in izip!(
+            &mult_from_triple,
+            &x_inputs_per_node[node_id],
+            &y_inputs_per_node[node_id],
+            &correct_a_sub_x,
+            &correct_b_sub_y
+        ) {
+            //(a−x)(b−y)
+            let mult_subs = subtraction_a * subtraction_b;
+            //(a−x)[y]_t
+            let mult_sub_a_y = input_b.clone().mul(*subtraction_a).expect("multiplication failed");
+            //(b−y)[x]_t
+            let mult_sub_b_x = input_a.clone().mul(*subtraction_b).expect("multiplication failed");
+            //[xy]_t
+            let share = triple_mult.clone().sub(mult_subs).expect("subtraction failed");
+            let share2: ShamirShare<Fr, 1, Robust> = (share - mult_sub_a_y).expect("subtraction failed");
+            let share3 = (share2 - mult_sub_b_x).expect("subtraction failed");
+            correct_shares.push(share3);
+        }
+
+        let config = FakeNetworkConfig::new(500);
+        let (network, mut receivers, _) = FakeNetwork::new(n, None, config);
+        let network = Arc::new(network);
+
+        let mut nodes: Vec<_> = (0..n).map(|i| { Multiply::<Fr, Avid>::new(i, n, t).unwrap() }).collect();
+
+        // all but one node call init
+        for i in 0..nodes.len() {
+            if i == node_id {
+                continue;
+            }
+
+            let mut node = nodes[i].clone();
+            let network = network.clone();
+            let x_inputs_per_node = x_inputs_per_node[i].clone();
+            let y_inputs_per_node = y_inputs_per_node[i].clone();
+            let beaver_triples = beaver_triples[i].clone();
+
+            tokio::spawn(async move {
+                assert!(node
+                    .init(session_id, x_inputs_per_node, y_inputs_per_node, beaver_triples, network)
+                    .await
+                    .is_ok());
+            });
+        }
+
+        // run RBC for masked input and eventually process it
+        for node in nodes.iter_mut() {
+            let network = network.clone();
+            let mut node = node.clone();
+            let mut receiver = receivers.remove(0);
+
+            tokio::spawn(async move {
+                while let Some(raw_msg) = receiver.recv().await {
+                    let wrapped: WrappedMessage = bincode::deserialize(&raw_msg).expect("deserialization error");
+
+                    match wrapped {
+                        WrappedMessage::BatchRecon(batchrecon_msg) => {
+                            node.batch_recon.process(batchrecon_msg, network.clone()).await.unwrap();
+                        }
+                        WrappedMessage::Rbc(rbc_msg) => {
+                            match node.rbc.process(rbc_msg, network.clone()).await {
+                                Ok(()) => { },
+                                Err(RbcError::SessionEnded(_)) => { },
+                                Err(e) => { panic!("unexpected error during RBC: {e}"); }
+                            }
+                        }
+                        WrappedMessage::Mul(input_msg) => {
+                            let _ = node.process(input_msg).await;
+                        }
+                        _ => { panic!(); }
+                    };
+                }
+            });
+        }
+
+        // wait for left out node to receive messages and calculate result
+        sleep(Duration::from_millis(500)).await;
+        
+        let storage_bind = nodes[node_id].get_or_create_mult_storage(session_id).await;
+        let storage = storage_bind.lock().await;
+
+        let no_of_batch = no_of_mul / (t + 1);
+
+        // all openings except for the RBC ones should be there, but enough shares
+        // for reconstruction should be there
+        assert!((0..no_of_batch).all(|i| storage.output_open_mult1.contains_key(&((2 * i) as u8))));
+        assert!((0..no_of_batch).all(|i| storage.output_open_mult2.contains_key(&((2 * i + 1) as u8))));
+        assert!(storage.openings.is_none());
+        assert!(storage.received_shares.len() >= 2 * t + 1);
+
+        drop(storage);
+
+        // so now we call init...
+        assert!(nodes[node_id]
+            .init(session_id, x_inputs_per_node[node_id].clone(), y_inputs_per_node[node_id].clone(), beaver_triples[node_id].clone(), network)
+            .await
+            .is_ok()
+        );
+
+        let storage_bind = nodes[node_id].get_or_create_mult_storage(session_id).await;
+        let storage = storage_bind.lock().await;
+
+        // openings via RBC should be there now
+        assert!(storage.openings.is_some());
+
+        drop(storage);
+
+        // ...and obtain the result
+        let mut real_shares = None;
+        match nodes[node_id].wait_for_result(session_id, Duration::from_millis(5)).await {
+            Err(MulError::ResultAlreadyReceived(_)) => { info!("already received result"); }
+            Err(e) => { panic!("unexpected error during waiting: {e}"); }
+            Ok(shares) => { real_shares = Some(shares); }
+        }
+
+        // 8. Check that shares are correct
+        assert!(real_shares.is_some());
+        for (real_share, correct_share) in real_shares.unwrap().into_iter().zip(correct_shares) {
+            assert_eq!(real_share.degree, t);
+            assert_eq!(real_share.id, node_id);
+            assert_eq!(real_share.share[0], correct_share.share[0]);
+        }
+    }
+
+    // 1. Generate Beaver triples
+    // 2. Prepare inputs for multiplication
+    // 3. Generate correct openings and shares
+    // 4. Create node
+    // 5. Generate messages
+    // 6. Shuffle messages
+    // 7. Make node handle messages
+    // 8. Check that shares are correct
+    #[tokio::test]
+    async fn test_open_mult_handler() {
+        let n_parties = 10;
+        let t = 3;
+        let node_id = 0;
+        let no_of_mul = 10;
+        let split_at = no_of_mul - no_of_mul % (t + 1);
+        let session_id = SessionId::new(ProtocolType::Mul, 123, 0, 0, 111);
+        let mut rng = test_rng();
+
+        // 1. Generate Beaver triples
+        let ((secrets_a, secrets_b, _), beaver_triples) = construct_input_mul(n_parties, no_of_mul, t).await;
+        let mult_from_triple: Vec<_> = beaver_triples[node_id]
+            .iter()
+            .map(|triple| triple.mult.clone())
+            .collect();
+
+        // 2. Prepare inputs for multiplication
+        let mut x_values = Vec::new();
+        let mut y_values = Vec::new();
+        let mut x_inputs_per_node = vec![Vec::new(); n_parties];
+        let mut y_inputs_per_node = vec![Vec::new(); n_parties];
+
+        for _i in 0..no_of_mul {
+            let x_value = Fr::rand(&mut rng);
+            x_values.push(x_value);
+            let y_value = Fr::rand(&mut rng);
+            y_values.push(y_value);
+
+            let shares_x = RobustShare::compute_shares(x_value, n_parties, t, None, &mut rng).unwrap();
+            let shares_y = RobustShare::compute_shares(y_value, n_parties, t, None, &mut rng).unwrap();
+
+            for p in 0..n_parties {
+                x_inputs_per_node[p].push(shares_x[p].clone());
+                y_inputs_per_node[p].push(shares_y[p].clone());
+            }
+        }
+
+        // 3. Generate correct openings and shares
+        let correct_a_sub_x = secrets_a.clone().iter().zip(x_values.clone()).map(|(a, x)| *a - x).collect::<Vec<_>>();
+        let correct_b_sub_y = secrets_b.clone().iter().zip(y_values.clone()).map(|(b, y)| *b - y).collect::<Vec<_>>();
+
+        let mut correct_shares = Vec::with_capacity(mult_from_triple.len());
+        for (triple_mult, input_a, input_b, subtraction_a, subtraction_b) in izip!(
+            &mult_from_triple,
+            &x_inputs_per_node[node_id],
+            &y_inputs_per_node[node_id],
+            &correct_a_sub_x,
+            &correct_b_sub_y
+        ) {
+            //(a−x)(b−y)
+            let mult_subs = subtraction_a * subtraction_b;
+            //(a−x)[y]_t
+            let mult_sub_a_y = input_b.clone().mul(*subtraction_a).expect("multiplication failed");
+            //(b−y)[x]_t
+            let mult_sub_b_x = input_a.clone().mul(*subtraction_b).expect("multiplication failed");
+            //[xy]_t
+            let share = triple_mult.clone().sub(mult_subs).expect("subtraction failed");
+            let share2: ShamirShare<Fr, 1, Robust> = (share - mult_sub_a_y).expect("subtraction failed");
+            let share3 = (share2 - mult_sub_b_x).expect("subtraction failed");
+            correct_shares.push(share3);
+        }
+
+        // 4. Create node
+        let mut mul_node = Multiply::<Fr, Avid>::new(node_id, n_parties, t).unwrap();
+
+        let storage_bind = mul_node.get_or_create_mult_storage(session_id).await;
+        let mut storage = storage_bind.lock().await;
+        storage.inputs = (x_inputs_per_node[node_id].clone(), y_inputs_per_node[node_id].clone());
+        storage.share_mult_from_triple = beaver_triples[node_id]
+            .iter()
+            .map(|triple| triple.mult.clone())
+            .collect();
+        storage.no_of_mul = Some(correct_a_sub_x.len());
+        drop(storage);
+
+        // 5. Generate messages
+        let mut mul_msgs = Vec::new();
+
+        let open_a_sub_x = correct_a_sub_x.clone()[0..split_at].to_vec();
+        let open_b_sub_y = correct_b_sub_y.clone()[0..split_at].to_vec();
+
+        // using batch reconstruction
+        for (i, (chunk_a, chunk_b)) in open_a_sub_x.chunks(t + 1).zip(open_b_sub_y.chunks(t + 1)).enumerate() {
+            let session_id_a = SessionId::new(
+                ProtocolType::Mul,
+                session_id.exec_id(),
+                1,
+                (2 * i) as u8,
+                session_id.instance_id(),
+            );
+            let session_id_b = SessionId::new(
+                ProtocolType::Mul,
+                session_id.exec_id(),
+                1,
+                (2 * i + 1) as u8,
+                session_id.instance_id(),
+            );
+
+            let mut chunk_a_bytes = Vec::new();
+            chunk_a
+                .serialize_compressed(&mut chunk_a_bytes)
+                .expect("serialization failed");
+            let chunk_a_msg = MultMessage::new(
+                node_id,
+                session_id_a,
+                chunk_a_bytes,
+            );
+
+            let mut chunk_b_bytes = Vec::new();
+            chunk_b
+                .serialize_compressed(&mut chunk_b_bytes)
+                .expect("serialization failed");
+            let chunk_b_msg = MultMessage::new(
+                node_id,
+                session_id_b,
+                chunk_b_bytes,
+            );
+
+            mul_msgs.push(chunk_a_msg);
+            mul_msgs.push(chunk_b_msg);
+        }
+
+        // using RBC
+        for i in 0..n_parties {
+            if i == node_id {
+                continue;
+            }
+
+            let shared_a_sub_x = x_inputs_per_node[i][split_at..]
+                .iter()
+                .zip(beaver_triples[i][split_at..].iter())
+                .map(|(x, triple)| triple.a.clone() - x.clone())
+                .collect::<Result<Vec<RobustShare<Fr>>, ShareError>>().expect("share subtraction failed");
+            let shared_b_sub_y = y_inputs_per_node[i][split_at..]
+                .iter()
+                .zip(beaver_triples[i][split_at..].iter())
+                .map(|(y, triple)| triple.b.clone() - y.clone())
+                .collect::<Result<Vec<RobustShare<Fr>>, ShareError>>().expect("share subtraction failed");
+
+            if shared_a_sub_x.len() > 0 && shared_b_sub_y.len() > 0 {
+                let rec_msg =
+                    ReconstructionMessage::new(shared_a_sub_x.to_vec(), shared_b_sub_y.to_vec());
+                let mut bytes_rec_msg = Vec::new();
+                rec_msg.serialize_compressed(&mut bytes_rec_msg).expect("serialization failed");
+            
+                let shared_session_id = SessionId::new(
+                    ProtocolType::Mul,
+                    session_id.exec_id(),
+                    2,
+                    mul_node.id as u8,
+                    session_id.instance_id()
+                );
+            
+                mul_msgs.push(MultMessage::new(i, shared_session_id, bytes_rec_msg));
+            }
+        }
+
+        // 6. Shuffle messages
+        mul_msgs.shuffle(&mut thread_rng());
+
+        // 7. Make node handle messages
+        for msg in mul_msgs {
+            let result = mul_node.process(msg).await;
+            match result {
+                Ok(()) => { }
+                Err(MulError::WaitForOk) => { info!("waiting"); }
+                Err(MulError::Duplicate(e)) => { panic!("duplicate detected: {e}") }
+                Err(e) => { panic!("unexpected error during processing: {e}"); }
+            }
+        }
+
+        let real_shares = match mul_node.wait_for_result(session_id, Duration::from_millis(1)).await {
+            Err(MulError::ResultAlreadyReceived(_)) => { panic!("already received result"); }
+            Err(e) => { panic!("unexpected error during waiting: {e}"); }
+            Ok(shares) => { Some(shares) }
+        };
+
+        // 8. Check that shares are correct
+        assert!(real_shares.is_some());
+        for (real_share, correct_share) in real_shares.unwrap().into_iter().zip(correct_shares) {
+            assert_eq!(real_share.degree, t);
+            assert_eq!(real_share.id, node_id);
+            assert_eq!(real_share.share[0], correct_share.share[0]);
+        }
     }
 }

--- a/mpc/tests/mul_test.rs
+++ b/mpc/tests/mul_test.rs
@@ -1,0 +1,244 @@
+pub mod utils;
+
+use crate::utils::test_utils::{
+    construct_e2e_input_mul, setup_tracing, test_setup,
+};
+use ark_bls12_381::Fr;
+use ark_ff::UniformRand;
+use ark_serialize::CanonicalSerialize;
+use ark_std::test_rng;
+use std::{
+    collections::HashMap, sync::Arc,
+    time::Duration, vec,
+};
+use stoffelmpc_mpc::common::{
+    rbc::rbc::Avid,
+    share::ShareError,
+    ShamirShare,
+    SecretSharingScheme, RBC
+};
+use stoffelmpc_mpc::honeybadger::{
+    mul::{
+        MulError, MultMessage, MultProtocolState,
+        ReconstructionMessage,
+        multiplication::Multiply
+    },
+    robust_interpolate::robust_interpolate::{Robust, RobustShare},
+    ProtocolType, SessionId, WrappedMessage,
+};
+use tokio::{
+    sync::mpsc::{self},
+    task::JoinSet,
+    sync::Mutex
+};
+use tracing::{info, warn};
+use itertools::izip;
+use std::ops::{Mul, Sub};
+use rand::{seq::SliceRandom,thread_rng};
+
+#[tokio::test]
+async fn mul_e2e_batch_recon_and_rbc() {
+    let n_parties = 10;
+    let t = 3;
+    let no_of_mul = 10;
+    // 2 times batch recon for chunks of size t+1=4
+    // 1 time RBC for the residue 2
+
+    mul_e2e(n_parties, t, no_of_mul).await;
+}
+
+#[tokio::test]
+async fn mul_e2e_only_batch_recon() {
+    let n_parties = 10;
+    let t = 3;
+    let no_of_mul = 8;
+    // 2 times batch recon for chunks of size t+1=4
+    // 0 times RBC for the residue 0
+
+    mul_e2e(n_parties, t, no_of_mul).await;
+}
+
+#[tokio::test]
+async fn mul_e2e_only_rbc() {
+    let n_parties = 10;
+    let t = 3;
+    let no_of_mul = 3;
+    // 0 times batch recon for chunks of size t+1=4
+    // 1 time RBC for the residue 3
+
+    mul_e2e(n_parties, t, no_of_mul).await;
+}
+
+// Steps:
+// 1. setup network
+// 2. generate Beaver triples
+// 3. Prepare inputs for multiplication
+// 4. Create nodes
+// 5. Init multiplication at each node
+// 6. Setup receive function for each node
+// 7. Collect results
+// 8. Compare with expected results
+async fn mul_e2e(n_parties: usize, t: usize, no_of_mul: usize) {
+    setup_tracing();
+
+    let mut rng = test_rng();
+    let session_id = SessionId::new(ProtocolType::Mul, 123, 0, 0, 111);
+
+    // 1. Setup network
+    let (network, mut receivers, _) = test_setup(n_parties, vec![]);
+    // 2. Generate Beaver triples
+    let (_, beaver_triples) = construct_e2e_input_mul(n_parties, no_of_mul, t).await;
+
+    // 3. Prepare inputs for multiplication
+    let mut x_values = Vec::new();
+    let mut y_values = Vec::new();
+    let mut x_inputs_per_node = vec![Vec::new(); n_parties];
+    let mut y_inputs_per_node = vec![Vec::new(); n_parties];
+
+    for _i in 0..no_of_mul {
+        let x_value = Fr::rand(&mut rng);
+        x_values.push(x_value);
+        let y_value = Fr::rand(&mut rng);
+        y_values.push(y_value);
+
+        let shares_x = RobustShare::compute_shares(x_value, n_parties, t, None, &mut rng).unwrap();
+        let shares_y = RobustShare::compute_shares(y_value, n_parties, t, None, &mut rng).unwrap();
+
+        for p in 0..n_parties {
+            x_inputs_per_node[p].push(shares_x[p].clone());
+            y_inputs_per_node[p].push(shares_y[p].clone());
+        }
+    }
+
+    // 4. Create nodes
+    let mut mul_nodes: Vec<_> = (0..n_parties)
+        .map(|id| Multiply::<Fr, Avid>::new(id, n_parties, t).unwrap())
+        .collect();
+
+    // 5. Init multiplication at each node
+    for i in 0..n_parties {
+        match mul_nodes[i].init(
+            session_id,
+            x_inputs_per_node[i].clone(),
+            y_inputs_per_node[i].clone(),
+            beaver_triples[i].clone(),
+            Arc::clone(&network)
+        ).await {
+            Ok(()) => (),
+            Err(e) => {
+                panic!(
+                    "Test: Unexpected error during init_handler for node {}: {:?}",
+                    mul_nodes[i].id, e
+                );
+            }
+        }
+    }
+    info!("nodes initialized");
+
+    // 6. Setup receive function for each node
+    let mut set = JoinSet::new();
+    for node in &mul_nodes {
+        let mut mul_node = node.clone();
+        let mut receiver = receivers.remove(0);
+        let net_clone = Arc::clone(&network);
+
+        set.spawn(async move {
+            while let Some(msg_bytes) = receiver.recv().await {
+                // Attempt to deserialize into WrappedMessage
+                let wrapped: WrappedMessage = match bincode::deserialize(&msg_bytes) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        warn!("failed to deserialize into wrapped message");
+                        continue;
+                    }
+                };
+                // Match the message type and route it appropriately
+                match &wrapped {
+                    WrappedMessage::Mul(msg) => {
+                        let result = mul_node
+                            .process(msg.clone())
+                            .await;
+
+                        match result {
+                            Ok(()) => { }
+                            Err(MulError::WaitForOk) => {info!("{} waiting", mul_node.id);}
+                            Err(MulError::ResultAlreadyReceived(_)) => { info!("{} already received result", mul_node.id); }
+                            Err(e) => {
+                                panic!(
+                                    "Node {} encountered unexpected error: {e}",
+                                    mul_node.id
+                                );
+                            }
+                        }
+                    }
+                    WrappedMessage::Rbc(msg) => {
+                        if let Err(e) = mul_node
+                            .rbc
+                            .process(msg.clone(), Arc::clone(&net_clone))
+                            .await
+                        {
+                            warn!("RBC processing error: {e}");
+                        }
+                    }
+                    WrappedMessage::BatchRecon(batch_msg) => {
+                        match batch_msg.session_id.calling_protocol() {
+                            Some(ProtocolType::Mul) => {
+                                mul_node
+                                    .batch_recon
+                                    .process(batch_msg.clone(), Arc::clone(&net_clone))
+                                    .await.expect("batch recon error")
+                            }
+                            _ => {
+                                panic!("Unexpected caller of batch recon");
+                            }
+                        }
+                    }
+                    _ => {
+                          panic!("Unexpected protocol type");
+                    }
+                }
+            }
+        });
+    }
+
+    info!("receiver task spawned");
+
+    // 7. Collect results
+    let mut final_results = HashMap::<usize, Vec<RobustShare<Fr>>>::new();
+    for i in 0..n_parties {
+        let node = &mul_nodes[i];
+        let final_shares = node.wait_for_result(session_id, Duration::from_millis(500)).await.unwrap();
+
+        final_results.insert(node.id, final_shares);
+        if final_results.len() == n_parties {
+            // check final_shares consist of correct shares
+            for (id, mul_shares) in &final_results {
+                assert_eq!(mul_shares.len(), no_of_mul);
+                let _ = mul_shares.iter().map(|mul_share| {
+                    assert_eq!(mul_share.degree, t);
+                    assert_eq!(mul_share.id, node.id);
+                });
+            }
+            break;
+        }
+    }
+
+    // 8. Compare with expected results
+    let mut per_multiplication_shares: Vec<Vec<RobustShare<Fr>>> =
+        vec![Vec::new(); no_of_mul];
+
+    for pid in 0..n_parties {
+        for i in 0..no_of_mul {
+            per_multiplication_shares[i].push(final_results.get(&pid).unwrap()[i].clone());
+        }
+    }
+
+    for i in 0..no_of_mul {
+        let shares_for_i = per_multiplication_shares[i][0..=(2 * t)].to_vec();
+        let (_, z_rec) =
+            RobustShare::recover_secret(&shares_for_i, n_parties).expect("interpolate failed");
+        let expected = x_values[i] * y_values[i];
+
+        assert_eq!(z_rec, expected, "multiplication mismatch at index {}", i);
+    }
+}

--- a/mpc/tests/utils/test_utils.rs
+++ b/mpc/tests/utils/test_utils.rs
@@ -545,7 +545,7 @@ pub async fn construct_e2e_input_mul(
     n_parties: usize,
     n_triples: usize,
     threshold: usize,
-) -> Vec<Vec<ShamirBeaverTriple<Fr>>> {
+) -> ((Vec<Fr>, Vec<Fr>, Vec<Fr>), Vec<Vec<ShamirBeaverTriple<Fr>>>) {
     let mut rng = test_rng();
     let mut secrets_a = Vec::new();
     let mut secrets_b = Vec::new();
@@ -581,7 +581,7 @@ pub async fn construct_e2e_input_mul(
             per_party_triples[pid].push(triple);
         }
     }
-    per_party_triples
+    ((secrets_a, secrets_b, secrets_c), per_party_triples)
 }
 
 //--------------------------CLIENT--------------------------


### PR DESCRIPTION
- allow init to be called at any point after open_mult_handler
- only initiate batch reconstruction and RBC for chunks that have not been opened yet
- cache values opened via RBC instead of recalculating each time that the final multiplication step is attempted; this avoids recalculation if init has not been called yet
- replace output channel mechanism with oneshot channels per session ID
- do not return shares from open_mult_handler
- add some documentation
- make diagnostic messages more informative
- fix typos in variable names (b_sub_x instead of the correct b_sub_y)
- remove extra variable t = self.threshold
- add local tests for multiplication