### PR TITLE
fix some problems raised by Hound

### DIFF
--- a/mpc/src/common/rbc/rbc.rs
+++ b/mpc/src/common/rbc/rbc.rs
@@ -1760,6 +1760,8 @@ impl ACS {
             "Initiating common subset"
         );
 
+        assert!(msg.session_id.calling_protocol().is_some());
+
         let mut store = self.store.lock().await;
 
         if !store.has_aba_input(msg.session_id.sub_id().into()) {

--- a/mpc/src/common/rbc/utils.rs
+++ b/mpc/src/common/rbc/utils.rs
@@ -121,13 +121,9 @@ impl Hasher for Sha256Algorithm {
     }
 }
 
-/// Hash a single shard using SHA-256.
-pub fn hash(shard: Vec<u8>) -> [u8; 32] {
-    Sha256Algorithm::hash(&shard)
-}
 /// Generate a Merkle tree from a list of shards.
 pub fn gen_merkletree(shards: Vec<Vec<u8>>) -> MerkleTree<Sha256Algorithm> {
-    let leaves: Vec<[u8; 32]> = shards.iter().map(|x| hash(x.clone())).collect();
+    let leaves: Vec<[u8; 32]> = shards.iter().map(|x| Sha256Algorithm::hash(&x)).collect();
     MerkleTree::<Sha256Algorithm>::from_leaves(&leaves)
 }
 /// Deserialize a Merkle proof from raw bytes (excluding the root).
@@ -153,7 +149,7 @@ pub fn verify_merkle(
         .try_into()
         .map_err(|_| ShardError::Merkle("Failed to extract Merkle root".to_string()))?;
     let proof = get_merkle_proof(proof)?;
-    let leaf_hash = hash(shard.clone());
+    let leaf_hash = Sha256Algorithm::hash(&shard);
 
     Ok(proof.verify(root, &vec![id], &[leaf_hash], n))
 }

--- a/mpc/src/honeybadger/fpmul/mod.rs
+++ b/mpc/src/honeybadger/fpmul/mod.rs
@@ -52,6 +52,8 @@ pub enum RandBitError {
     ShareError(#[from] ShareError),
     #[error("error sending the finished session ID to the caller: {0:?}")]
     SenderError(#[from] SendError<SessionId>),
+    #[error("unknown calling protocol in session ID {0:?}")]
+    SessionIdError(SessionId),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -130,6 +132,8 @@ pub enum PRandError {
     NotSet(String),
     #[error("ShareError: {0}")]
     ShareError(#[from] ShareError),
+    #[error("unknown calling protocol in session ID {0:?}")]
+    SessionIdError(SessionId),
     #[error("error sending the finished session ID to the caller: {0:?}")]
     SenderError(#[from] SendError<SessionId>),
     #[error("F2_8 Error: {0}")]
@@ -264,6 +268,8 @@ pub enum TruncPrError {
     SendError(#[from] SendError<SessionId>),
     #[error("InterpolateError: {0}")]
     InterpolateError(#[from] InterpolateError),
+    #[error("unknown calling protocol in session ID {0:?}")]
+    SessionIdError(SessionId)
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/mpc/src/honeybadger/fpmul/rand_bit.rs
+++ b/mpc/src/honeybadger/fpmul/rand_bit.rs
@@ -110,6 +110,9 @@ where
         if a.len() % (self.threshold + 1) != 0 {
             return Err(RandBitError::Incompatible);
         }
+
+        assert!(session_id.calling_protocol().is_some());
+
         // Mark the protocol as initialized.
         {
             let storage_bind = self.get_or_create_storage(session_id).await;
@@ -152,8 +155,16 @@ where
             "Rand_bit reconstruction msg received from node: {0:?}",
             message.sender
         );
+
+        let calling_proto = match message.session_id.calling_protocol() {
+            Some(proto) => proto,
+            None => {
+                return Err(RandBitError::SessionIdError(message.session_id));
+            }
+        };
+
         let session_id = SessionId::new(
-            message.session_id.calling_protocol().unwrap(),
+            calling_proto,
             message.session_id.exec_id(),
             0,
             0,

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -69,6 +69,13 @@ impl<F: PrimeField, R: RBC> TruncPrNode<F, R> {
     ) -> Result<(), TruncPrError> {
         info!(node_id = self.id, "TruncPr start");
 
+        let calling_proto = match session.calling_protocol() {
+            Some(proto) => proto,
+            None => {
+                return Err(TruncPrError::SessionIdError(session));
+            }
+        };
+
         let store = self.get_or_create_store(session).await; // k,m already set in store
         let mut s = store.lock().await;
         s.k = k;
@@ -98,7 +105,7 @@ impl<F: PrimeField, R: RBC> TruncPrNode<F, R> {
         let bytes_wrapped = bincode::serialize(&wrapped)?;
 
         let sessionid = SessionId::new(
-            session.calling_protocol().unwrap(),
+            calling_proto,
             session.exec_id(),
             0,
             self.id as u8,

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -179,6 +179,8 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
             return Err(MulError::InvalidInput("Length of x and y vectors and Beaver triples must match".to_string()));
         }
 
+        assert!(session_id.calling_protocol().is_some());
+
         let no_of_mul = x.len();
         let no_of_batch = no_of_mul / (self.t + 1);
         let share_len = x.len() % (self.t + 1);
@@ -331,8 +333,17 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         &self,
         msg: MultMessage,
     ) -> Result<(), MulError> {
+        let calling_proto = match msg.session_id.calling_protocol() {
+            Some(proto) => proto,
+            None => {
+                return Err(MulError::InvalidInput(
+                    format!("Unknown calling protocol in session ID {:?}", msg.session_id)
+                ));
+            }
+        };
+
         let session_id = SessionId::new(
-            msg.session_id.calling_protocol().unwrap(),
+            calling_proto,
             msg.session_id.exec_id(),
             0,
             0,

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -82,10 +82,6 @@ pub struct RanDouShaStore<F: FftField> {
 pub enum RanDouShaState {
     /// The protocol has been initialized.
     Initialized,
-    /// The protocol is in the reconstruction phase.
-    Reconstruction,
-    /// The protocol is in the output phase.
-    Output,
     /// The protocol has been finished.
     Finished,
 }
@@ -289,8 +285,6 @@ where
         let binding = self.get_or_create_store(msg.session_id).await;
         let mut store = binding.lock().await;
 
-        store.state = RanDouShaState::Reconstruction;
-
         let sender_id = msg.sender_id;
         store
             .received_r_shares_degree_t
@@ -379,8 +373,6 @@ where
         }
         let binding = self.get_or_create_store(msg.session_id).await;
         let mut store = binding.lock().await;
-
-        store.state = RanDouShaState::Output;
 
         // push to received_ok_msg if sender doesn't exist
         if !store.received_ok_msg.contains(&msg.sender_id) {

--- a/mpc/tests/randousha_test.rs
+++ b/mpc/tests/randousha_test.rs
@@ -220,7 +220,6 @@ async fn test_reconstruct_handler() {
     assert!(store.received_r_shares_degree_t.len() == 2 * threshold + 1);
     assert!(store.received_r_shares_degree_2t.len() == 2 * threshold + 1);
     assert!(store.received_ok_msg.len() == 0);
-    assert!(store.state == RanDouShaState::Reconstruction);
 }
 
 #[tokio::test]
@@ -331,7 +330,6 @@ async fn test_reconstruct_handler_mismatch_r_t_2t() {
     assert_eq!(store.received_r_shares_degree_t.len(), n_parties);
     assert_eq!(store.received_r_shares_degree_2t.len(), n_parties);
     assert_eq!(store.received_ok_msg.len(), 0);
-    assert_eq!(store.state, RanDouShaState::Reconstruction);
 }
 
 #[tokio::test]


### PR DESCRIPTION
- prevent a malicious msg from triggering panic Calling `calling_protocol().unwrap()` results in a panic if the calling protocol actually is not valid. A malicious node could craft a message with an invalid calling protocol to make honest nodes crash like this. To fix this, return an error instead of crashing.
- remove intermediate states in random double sharing These states only served for debugging and were easy to manipulate by a malicious node sending fake messages to trigger the assignment of a state.
- remove unnecessary cloning