### PR TITLE
check session IDs and add limits

### DIFF
--- a/mpc/src/ffi/c_bindings/honey_badger_mpc_client/mod.rs
+++ b/mpc/src/ffi/c_bindings/honey_badger_mpc_client/mod.rs
@@ -44,6 +44,8 @@ pub enum HoneyBadgerErrorCode {
     HoneyBadgerFPDivConstError,
     HoneyBadgerTypesError,
     HoneyBadgerAlreadyReservedError,
+    HoneyBadgerLimitError,
+    HoneyBadgerInstanceIdError,
 }
 
 impl From<HoneyBadgerError> for HoneyBadgerErrorCode {
@@ -71,6 +73,8 @@ impl From<HoneyBadgerError> for HoneyBadgerErrorCode {
             HoneyBadgerError::TruncPrError(_) => Self::HoneyBadgerTruncPrError,
             HoneyBadgerError::FPDivConstError(_) => Self::HoneyBadgerFPDivConstError,
             HoneyBadgerError::TypeError(_) => Self::HoneyBadgerTypesError,
+            HoneyBadgerError::LimitError => Self::HoneyBadgerLimitError,
+            HoneyBadgerError::InstanceIdError(_) => Self::HoneyBadgerInstanceIdError,
             HoneyBadgerError::AlreadyReserved => Self::HoneyBadgerAlreadyReservedError,
         }
     }

--- a/mpc/src/honeybadger/fpmul/mod.rs
+++ b/mpc/src/honeybadger/fpmul/mod.rs
@@ -52,6 +52,10 @@ pub enum RandBitError {
     ShareError(#[from] ShareError),
     #[error("error sending the finished session ID to the caller: {0:?}")]
     SenderError(#[from] SendError<SessionId>),
+    #[error("unknown calling protocol in session ID {0:?}")]
+    SessionIdError(SessionId),
+    #[error("cannot create {0:?} random bits at once")]
+    LimitError(usize)
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -264,6 +268,8 @@ pub enum TruncPrError {
     SendError(#[from] SendError<SessionId>),
     #[error("InterpolateError: {0}")]
     InterpolateError(#[from] InterpolateError),
+    #[error("malformed session ID {0:?}")]
+    SessionIdError(SessionId)
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/mpc/src/honeybadger/fpmul/prandbitd.rs
+++ b/mpc/src/honeybadger/fpmul/prandbitd.rs
@@ -76,6 +76,10 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
         network: Arc<N>,
     ) -> Result<(), PRandError> {
         info!(node_id = self.id, "RISS started");
+
+        assert_eq!(session_id.sub_id(), 0);
+        assert_eq!(session_id.round_id(), 0);
+
         if batch_size % (self.t + 1) != 0
             && session_id.calling_protocol() == Some(ProtocolType::PRandBit)
         {
@@ -381,6 +385,9 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
         session_id: SessionId,
     ) -> Arc<Mutex<PRandBitDStore<F, G>>> {
         let mut storage = self.store.lock().await;
+
+        // should never happen, since only exec ID changes for different runs
+        assert!(storage.len() <= 256);
         storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(PRandBitDStore::empty())))

--- a/mpc/src/honeybadger/fpmul/rand_bit.rs
+++ b/mpc/src/honeybadger/fpmul/rand_bit.rs
@@ -91,6 +91,9 @@ where
         session_id: SessionId,
     ) -> Arc<Mutex<RandBitStorage<F>>> {
         let mut storage = self.storage.lock().await;
+
+        // only exec ID changes between different runs
+        assert!(storage.len() <= 256);
         storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(RandBitStorage::empty())))
@@ -110,6 +113,15 @@ where
         if a.len() % (self.threshold + 1) != 0 {
             return Err(RandBitError::Incompatible);
         }
+
+        if a.len() / (self.threshold + 1) > 256 {
+            return Err(RandBitError::LimitError(a.len()));
+        }
+
+        assert!(session_id.calling_protocol().is_some());
+        assert_eq!(session_id.sub_id(), 0);
+        assert_eq!(session_id.round_id(), 0);
+
         // Mark the protocol as initialized.
         {
             let storage_bind = self.get_or_create_storage(session_id).await;
@@ -245,5 +257,37 @@ where
     pub async fn process(&mut self, message: RandBitMessage) -> Result<(), RandBitError> {
         self.square_reconstruction_handler(message).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
+    use crate::honeybadger::triple_gen::ShamirBeaverTriple;
+    use crate::common::rbc::rbc::Avid;
+    use ark_bls12_381::Fr;
+    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use stoffelmpc_network::fake_network::{FakeNetwork, FakeNetworkConfig};
+
+    #[tokio::test]
+    async fn test_randbit_init_storage_limit() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RandBit::<Fr, Avid>::new(0, 5, 1, tx).unwrap();
+        let session_id = SessionId::new(crate::honeybadger::ProtocolType::RandBit, 0, 0, 0, 111);
+
+        // threshold + 1 = 2, so 2 * 257 elements will exceed the 256 batch limit
+        let a = vec![RobustShare::new(Fr::from(1u8), 0, 1); 257 * 2];
+        let triples = vec![ShamirBeaverTriple {
+            a: RobustShare::new(Fr::from(1u8), 0, 1),
+            b: RobustShare::new(Fr::from(1u8), 0, 1),
+            mult: RobustShare::new(Fr::from(1u8), 0, 1),
+        }; 257 * 2];
+
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(100)).0);
+
+        let result = node.init(a, triples, session_id, net).await;
+        assert!(matches!(result, Err(RandBitError::LimitError(_))), "Should error on exceeding storage limit");
     }
 }

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -43,6 +43,10 @@ impl<F: PrimeField, R: RBC> TruncPrNode<F, R> {
 
     pub async fn get_or_create_store(&mut self, session: SessionId) -> Arc<Mutex<TruncPrStore<F>>> {
         let mut map = self.store.lock().await;
+
+        // should always hold, since only exec ID changes between different sessions
+        assert!(map.len() <= 256);
+
         map.entry(session)
             .or_insert((|| Arc::new(Mutex::new(TruncPrStore::empty())))())
             .clone()
@@ -120,6 +124,11 @@ impl<F: PrimeField, R: RBC> TruncPrNode<F, R> {
             sender = msg.sender_id,
             "TruncPr open handler"
         );
+
+        if msg.session_id.sub_id() != 0 || msg.session_id.round_id() != 0 {
+            return Err(TruncPrError::SessionIdError(msg.session_id));
+        }
+
         let store = self.get_or_create_store(msg.session_id).await;
         let mut s = store.lock().await;
 
@@ -173,5 +182,40 @@ impl<F: PrimeField, R: RBC> TruncPrNode<F, R> {
     ) -> Result<(), TruncPrError> {
         self.handle_open(msg).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
+    use crate::common::rbc::rbc::Avid;
+    use crate::honeybadger::SessionId;
+    use crate::honeybadger::fpmul::{TruncPrMessage, TruncPrError};
+    use ark_bls12_381::Fr;
+    use ark_serialize::CanonicalSerialize;
+    use tokio::sync::mpsc;
+
+    #[tokio::test]
+    async fn test_truncpr_handle_open_invalid_sub_id() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = TruncPrNode::<Fr, Avid>::new(0, 5, 1, tx).unwrap();
+
+        // Create a session id with sub_id != 0
+        let session_id = SessionId::new(crate::honeybadger::ProtocolType::Trunc, 0, 1, 0, 111);
+
+        // Create a dummy payload
+        let dummy_share = RobustShare::new(Fr::from(1u8), 0, 1);
+        let mut payload = Vec::new();
+        dummy_share.serialize_compressed(&mut payload).unwrap();
+
+        let msg = TruncPrMessage::new(0, session_id, payload);
+
+        // Should return a SessionIdError due to sub_id != 0
+        let result = node.handle_open(msg).await;
+        match result {
+            Err(TruncPrError::SessionIdError(sid)) => assert_eq!(sid, session_id),
+            _ => panic!("Expected SessionIdError for invalid sub_id"),
+        }
     }
 }

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -130,8 +130,12 @@ pub enum HoneyBadgerError {
     BincodeSerializationError(#[from] Box<ErrorKind>),
     #[error("failed to join spawned task")]
     JoinError,
+    #[error("instance ID {0:?} is incorrect")]
+    InstanceIdError(u32),
     #[error("output channel closed before result was received")]
     ChannelClosed,
+    #[error("the protocol cannot be executed any more")]
+    LimitError
 }
 
 pub struct HoneyBadgerMPCClient<F: FftField, R: RBC> {
@@ -239,21 +243,33 @@ pub struct OutputChannels {
 }
 
 #[derive(Clone, Debug)]
-pub struct SubProtocolCounter(Arc<AtomicU8>);
+pub struct SubProtocolCounter(Arc<Mutex<Option<u8>>>);
 
 trait GetNext<T> {
-    fn get_next(&self) -> T;
+    async fn get_next(&self) -> Result<T, HoneyBadgerError>;
 }
 
 impl GetNext<u8> for SubProtocolCounter {
-    fn get_next(&self) -> u8 {
-        self.0.fetch_add(1, Ordering::SeqCst)
+    async fn get_next(&self) -> Result<u8, HoneyBadgerError> {
+        let mut counter = self.0.lock().await;
+
+        match &mut *counter {
+            None => Err(HoneyBadgerError::LimitError),
+            Some(value) => {
+                let current = *value;
+                if *value == 255 {
+                    *counter = None;
+                } else {
+                    *value += 1;
+                }
+                Ok(current)
+            }
+        }
     }
 }
 
 /// Per sub-protocol there is a counter to increment the exec ID within the
 /// session ID and distinguish different executions of the same sub-protocol.
-/// Since the exec ID is a `u8`, the counter is an `AtomicU8`.
 #[derive(Clone, Debug)]
 pub struct SubProtocolCounters {
     pub ran_dou_sha_counter: SubProtocolCounter,
@@ -272,17 +288,17 @@ pub struct SubProtocolCounters {
 impl SubProtocolCounters {
     pub fn new() -> Self {
         Self {
-            ran_dou_sha_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            ran_sha_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            triple_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            batch_recon_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            dou_sha_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            mul_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            rand_bit_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            prand_bit_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            prand_int_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            fpmul_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0))),
-            fpdiv_const_counter: SubProtocolCounter(Arc::new(AtomicU8::new(0)))
+            ran_dou_sha_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            ran_sha_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            triple_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            batch_recon_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            dou_sha_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            mul_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            rand_bit_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            prand_bit_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            prand_int_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            fpmul_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0)))),
+            fpdiv_const_counter: SubProtocolCounter(Arc::new(Mutex::new(Some(0))))
         }
     }
 }
@@ -456,7 +472,7 @@ where
             .await
             .take_beaver_triples(x.len())?;
 
-        let session_id = SessionId::new(ProtocolType::Mul, self.counters.mul_counter.get_next(), 0, 0, self.params.instance_id);
+        let session_id = SessionId::new(ProtocolType::Mul, self.counters.mul_counter.get_next().await?, 0, 0, self.params.instance_id);
 
         // Call the mul function
         self.operations
@@ -471,59 +487,66 @@ where
         let wrapped: WrappedMessage = bincode::deserialize(&raw_msg)?;
 
         match wrapped {
-            WrappedMessage::Rbc(rbc_msg) => match rbc_msg.session_id.calling_protocol() {
-                Some(ProtocolType::Randousha) => {
-                    self.preprocess
-                        .ran_dou_sha
-                        .rbc
-                        .process(rbc_msg, net)
-                        .await?
+            WrappedMessage::Rbc(rbc_msg) => {
+                if rbc_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(rbc_msg.session_id.instance_id()));
                 }
-                Some(ProtocolType::Ransha) => {
-                    self.preprocess.share_gen.rbc.process(rbc_msg, net).await?
-                }
-                Some(ProtocolType::Input) => {
-                    self.preprocess.input.rbc.process(rbc_msg, net).await?
-                }
-                Some(ProtocolType::Mul) => self.operations.mul.rbc.process(rbc_msg, net).await?,
-                Some(ProtocolType::RandBit) => {
-                    self.preprocess
-                        .rand_bit
-                        .mult_node
-                        .rbc
-                        .process(rbc_msg, net)
-                        .await?
-                }
-                Some(ProtocolType::FpMul) => {
-                    if rbc_msg.session_id.sub_id() == 0 {
-                        self.type_ops
-                            .fpmul
-                            .trunc_node
+
+                match rbc_msg.session_id.calling_protocol() {
+                    Some(ProtocolType::Randousha) => {
+
+                        self.preprocess
+                            .ran_dou_sha
                             .rbc
                             .process(rbc_msg, net)
                             .await?
-                    } else {
-                        self.type_ops
-                            .fpmul
+                    }
+                    Some(ProtocolType::Ransha) => {
+                        self.preprocess.share_gen.rbc.process(rbc_msg, net).await?
+                    }
+                    Some(ProtocolType::Input) => {
+                        self.preprocess.input.rbc.process(rbc_msg, net).await?
+                    }
+                    Some(ProtocolType::Mul) => self.operations.mul.rbc.process(rbc_msg, net).await?,
+                    Some(ProtocolType::RandBit) => {
+                        self.preprocess
+                            .rand_bit
                             .mult_node
                             .rbc
                             .process(rbc_msg, net)
                             .await?
                     }
-                }
-                Some(ProtocolType::FpDivConst) => {
-                    self.type_ops
-                        .fpdiv_const
-                        .trunc_node
-                        .rbc
-                        .process(rbc_msg, net)
-                        .await?
-                }
-                _ => {
-                    warn!(
-                        "Unknown protocol ID in session ID: {:?} in RBC",
-                        rbc_msg.session_id
-                    );
+                    Some(ProtocolType::FpMul) => {
+                        if rbc_msg.session_id.sub_id() == 0 {
+                            self.type_ops
+                                .fpmul
+                                .trunc_node
+                                .rbc
+                                .process(rbc_msg, net)
+                                .await?
+                        } else {
+                            self.type_ops
+                                .fpmul
+                                .mult_node
+                                .rbc
+                                .process(rbc_msg, net)
+                                .await?
+                        }
+                    }
+                    Some(ProtocolType::FpDivConst) => {
+                        self.type_ops
+                            .fpdiv_const
+                            .trunc_node
+                            .rbc
+                            .process(rbc_msg, net)
+                            .await?
+                    }
+                    _ => {
+                        warn!(
+                            "Unknown protocol ID in session ID: {:?} in RBC",
+                            rbc_msg.session_id
+                        );
+                    }
                 }
             },
 
@@ -531,31 +554,52 @@ where
                 self.preprocess.input.process(input).await?;
             }
             WrappedMessage::RanSha(rs_msg) => {
+                if rs_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(rs_msg.session_id.instance_id()));
+                }
                 self.preprocess.share_gen.process(rs_msg, net).await?;
             }
             WrappedMessage::Dousha(ds_msg) => {
+                if ds_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(ds_msg.session_id.instance_id()));
+                }
                 self.preprocess.dou_sha.process(ds_msg).await?;
             }
             WrappedMessage::RanDouSha(rds_msg) => {
+                if rds_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(rds_msg.session_id.instance_id()));
+                }
                 self.preprocess.ran_dou_sha.process(rds_msg, net).await?;
             }
-            WrappedMessage::Mul(mul_msg) => match mul_msg.session_id.calling_protocol() {
-                Some(ProtocolType::Mul) => self.operations.mul.process(mul_msg).await?,
-                Some(ProtocolType::RandBit) => {
-                    self.preprocess.rand_bit.mult_node.process(mul_msg).await?
+            WrappedMessage::Mul(mul_msg) => {
+                if mul_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(mul_msg.session_id.instance_id()));
                 }
-                Some(ProtocolType::FpMul) => self.type_ops.fpmul.mult_node.process(mul_msg).await?,
-                _ => {
-                    warn!(
-                        "Unknown protocol ID in session ID: {:?} in MUL",
-                        mul_msg.session_id
-                    );
+
+                match mul_msg.session_id.calling_protocol() {
+                    Some(ProtocolType::Mul) => self.operations.mul.process(mul_msg).await?,
+                    Some(ProtocolType::RandBit) => {
+                        self.preprocess.rand_bit.mult_node.process(mul_msg).await?
+                    }
+                    Some(ProtocolType::FpMul) => self.type_ops.fpmul.mult_node.process(mul_msg).await?,
+                    _ => {
+                        warn!(
+                            "Unknown protocol ID in session ID: {:?} in MUL",
+                            mul_msg.session_id
+                        );
+                    }
                 }
             },
             WrappedMessage::Triple(triple_msg) => {
+                if triple_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(triple_msg.session_id.instance_id()));
+                }
                 self.preprocess.triple_gen.process(triple_msg).await?;
             }
             WrappedMessage::BatchRecon(batch_msg) => {
+                if batch_msg.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(batch_msg.session_id.instance_id()));
+                }
                 match batch_msg.session_id.calling_protocol() {
                     Some(ProtocolType::Mul) => {
                         self.operations
@@ -611,15 +655,24 @@ where
                 }
             }
             WrappedMessage::RandBit(rand_bit_message) => {
+                if rand_bit_message.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(rand_bit_message.session_id.instance_id()));
+                }
                 self.preprocess.rand_bit.process(rand_bit_message).await?;
             }
             WrappedMessage::PRandBit(prand_message) => {
+                if prand_message.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(prand_message.session_id.instance_id()));
+                }
                 self.preprocess
                     .prand_bit
                     .process(prand_message, net)
                     .await?;
             }
             WrappedMessage::Trunc(trunc_message) => {
+                if trunc_message.session_id.instance_id() != self.params.instance_id {
+                    return Err(HoneyBadgerError::InstanceIdError(trunc_message.session_id.instance_id()));
+                }
                 match trunc_message.session_id.calling_protocol() {
                     Some(ProtocolType::FpMul) => {
                         self.type_ops
@@ -729,7 +782,7 @@ where
             .await
             .take_prandint_shares(1)?;
 
-        let session_id = SessionId::new(ProtocolType::FpMul, self.counters.fpmul_counter.get_next(), 0, 0, self.params.instance_id);
+        let session_id = SessionId::new(ProtocolType::FpMul, self.counters.fpmul_counter.get_next().await?, 0, 0, self.params.instance_id);
         let r_bits = r_bits_vec.iter().map(|(a, _)| a.clone()).collect();
 
         // Call the fpmul function
@@ -810,7 +863,7 @@ where
         // 4. Prepare SessionId --------------------------------------------
         let session_id = SessionId::new(
             ProtocolType::FpDivConst,
-            self.counters.fpdiv_const_counter.get_next(),
+            self.counters.fpdiv_const_counter.get_next().await?,
             0,
             0,
             self.params.instance_id
@@ -989,6 +1042,11 @@ where
             info!("There are enough Random shares and Beaver triples");
             // return Ok(());
         } else {
+            let mut triple_counter = self.counters.triple_counter.get_next().await?;
+            if (256 - triple_counter as usize) * 255 < total_triples_to_generate / group_size {
+                return Err(HoneyBadgerError::LimitError);
+            }
+
             // ------------------------
             // Step 1. Ensure random shares
             // ------------------------
@@ -1024,7 +1082,6 @@ where
             let a_chunks = random_shares_a.chunks_exact(group_size);
             let b_chunks = random_shares_b.chunks_exact(group_size);
             let r_chunks = ran_dou_sha_pair[..total_triples_to_generate].chunks_exact(group_size);
-            let mut triple_counter = self.counters.triple_counter.get_next();
             let mut round_id = 0u8;
 
             for ((a, b), r) in a_chunks.zip(b_chunks).zip(r_chunks) {
@@ -1071,7 +1128,7 @@ where
                 }
 
                 if round_id == 255 {
-                    triple_counter = self.counters.triple_counter.get_next();
+                    triple_counter = self.counters.triple_counter.get_next().await.unwrap();
                     round_id = 0;
                 } else {
                     round_id += 1;
@@ -1112,7 +1169,11 @@ where
         let batch = self.params.n_parties - 2 * self.params.threshold;
         let run = (needed + batch - 1) / batch; // ceil(missing / batch)
         let mut round_id = 0u8;
-        let mut ran_sha_counter = self.counters.ran_sha_counter.get_next();
+        let mut ran_sha_counter = self.counters.ran_sha_counter.get_next().await?;
+
+        if (256 - ran_sha_counter as usize) * 255 < run {
+            return Err(HoneyBadgerError::LimitError);
+        }
 
         for i in 0..run {
             info!("Random share generation run {}", i);
@@ -1149,7 +1210,7 @@ where
             }
 
             if round_id == 255 {
-                ran_sha_counter = self.counters.ran_sha_counter.get_next();
+                ran_sha_counter = self.counters.ran_sha_counter.get_next().await.unwrap();
                 round_id = 0;
             } else {
                 round_id += 1;
@@ -1178,7 +1239,11 @@ where
         let batch = self.params.threshold + 1;
         let run = (needed + batch - 1) / batch; // ceil(missing / batch)
         let mut round_id = 0u8;
-        let mut ran_dou_sha_counter = self.counters.ran_dou_sha_counter.get_next();
+        let mut ran_dou_sha_counter = self.counters.ran_dou_sha_counter.get_next().await?;
+
+        if (256 - ran_dou_sha_counter as usize) * 255 < run {
+            return Err(HoneyBadgerError::LimitError);
+        }
 
         for _ in 0..run {
             let sessionid =
@@ -1216,7 +1281,7 @@ where
             }
 
             if round_id == 255 {
-                ran_dou_sha_counter = self.counters.ran_dou_sha_counter.get_next();
+                ran_dou_sha_counter = self.counters.ran_dou_sha_counter.get_next().await.unwrap();
                 round_id = 0;
             } else {
                 round_id += 1;
@@ -1287,13 +1352,24 @@ where
         // Randbit share generation
         info!("Randbit share generation run");
 
-        let sessionid = SessionId::new(
+        let randbit_sessionid = SessionId::new(
             ProtocolType::RandBit,
-            self.counters.rand_bit_counter.get_next(),
+            self.counters.rand_bit_counter.get_next().await?,
             0,
             0,
             self.params.instance_id
         );
+
+        //Prandbit share generation
+        info!("PRandbit share generation");
+        let prandbit_sessionid = SessionId::new(
+            ProtocolType::PRandBit,
+            self.counters.prand_bit_counter.get_next().await?,
+            0,
+            0,
+            self.params.instance_id
+        );
+
 
         let random_shares_a = self
             .preprocessing_material
@@ -1310,7 +1386,7 @@ where
         // Run Randbit share protocol
         self.preprocess
             .rand_bit
-            .init(random_shares_a, beaver_triples, sessionid, network.clone())
+            .init(random_shares_a, beaver_triples, randbit_sessionid, network.clone())
             .await?;
 
         // Collect its output
@@ -1322,7 +1398,7 @@ where
             .recv()
             .await
         {
-            if id == sessionid {
+            if id == randbit_sessionid {
                 let mut share_store = self.preprocess.rand_bit.storage.lock().await;
                 let store_lock = share_store.remove(&id).unwrap();
                 let store = store_lock.lock().await;
@@ -1336,21 +1412,11 @@ where
         // Clear stores
         self.preprocess.rand_bit.clear_store().await;
 
-        //Prandbit share generation
-        info!("PRandbit share generation");
-        let sessionid = SessionId::new(
-            ProtocolType::PRandBit,
-            self.counters.prand_bit_counter.get_next(),
-            0,
-            0,
-            self.params.instance_id
-        );
-
         // Run PRandBit protocol
         self.preprocess
             .prand_bit
             .generate_riss(
-                sessionid,
+                prandbit_sessionid,
                 randbit_output,
                 self.params.l,
                 self.params.k,
@@ -1368,7 +1434,7 @@ where
             .recv()
             .await
         {
-            if id == sessionid {
+            if id == prandbit_sessionid {
                 let mut share_store = self.preprocess.prand_bit.store.lock().await;
                 let store_lock = share_store.remove(&id).unwrap();
                 let store = store_lock.lock().await;
@@ -1412,7 +1478,7 @@ where
         info!("PRandInt share generation");
         let sessionid = SessionId::new(
             ProtocolType::PRandInt,
-            self.counters.prand_int_counter.get_next(),
+            self.counters.prand_int_counter.get_next().await?,
             0,
             0,
             self.params.instance_id
@@ -1696,6 +1762,8 @@ impl SessionId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::Mutex;
+    use std::sync::Arc;
 
     #[test]
     fn test_session_id_debug_format() {
@@ -1739,5 +1807,17 @@ mod tests {
         );
 
         assert_eq!(session_id, session_id2);
+    }
+
+    #[tokio::test]
+    async fn test_subprotocol_counter_limit_error() {
+        let counter = SubProtocolCounter(Arc::new(Mutex::new(Some(255))));
+        // First call should return 255
+        let val = counter.get_next().await;
+        assert_eq!(val.unwrap(), 255);
+
+        // Second call should return error (None)
+        let err = counter.get_next().await;
+        assert!(matches!(err, Err(HoneyBadgerError::LimitError)));
     }
 }

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -179,6 +179,10 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
             return Err(MulError::InvalidInput("Length of x and y vectors and Beaver triples must match".to_string()));
         }
 
+        assert!(session_id.calling_protocol().is_some());
+        assert_eq!(session_id.sub_id(), 0);
+        assert_eq!(session_id.round_id(), 0);
+
         let no_of_mul = x.len();
         let no_of_batch = no_of_mul / (self.t + 1);
         let share_len = x.len() % (self.t + 1);
@@ -444,6 +448,10 @@ impl<F: FftField, R: RBC> Multiply<F, R> {
         session_id: SessionId,
     ) -> Arc<Mutex<MultStorage<F>>> {
         let mut storage = self.mult_storage.lock().await;
+
+        // should never occur, since only exec ID changes for different runs
+        assert!(storage.len() <= 256);
+
         storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(MultStorage::empty())))

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -46,7 +46,7 @@ pub enum RanDouShaError {
     #[error("Interpolate error: {0}")]
     InterpolateError(#[from] InterpolateError),
     /// The protocol received an abort signal.
-    #[error("received abort singal")]
+    #[error("received abort signal")]
     Abort,
     /// The party is waiting for confirmations.
     #[error("waiting for more confirmations")]
@@ -55,6 +55,10 @@ pub enum RanDouShaError {
     SendError(#[from] SendError<SessionId>),
     #[error("ShareError: {0}")]
     ShareError(#[from] ShareError),
+    #[error("session ID {0:?} malformed")]
+    SessionIdError(SessionId),
+    #[error("limit reached")]
+    LimitError
 }
 
 /// Storage for the Random Double Sharing protocol.
@@ -124,6 +128,8 @@ pub struct RanDouShaNode<F: FftField, R: RBC> {
     pub rbc: R,
 }
 
+pub static MAX_RAN_DOU_SHA_SESSIONS: usize = 1024;
+
 impl<F, R> RanDouShaNode<F, R>
 where
     F: FftField,
@@ -174,12 +180,17 @@ where
     pub async fn get_or_create_store(
         &mut self,
         session_id: SessionId,
-    ) -> Arc<Mutex<RanDouShaStore<F>>> {
+    ) -> Result<Arc<Mutex<RanDouShaStore<F>>>, RanDouShaError> {
         let mut storage = self.store.lock().await;
-        storage
+
+        if storage.len() == MAX_RAN_DOU_SHA_SESSIONS {
+            return Err(RanDouShaError::LimitError);
+        }
+
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(RanDouShaStore::empty())))
-            .clone()
+            .clone())
     }
 
     /// Implements the initialization phase of the Random double share protocol. In particular,
@@ -210,6 +221,9 @@ where
             self.id,
             session_id.as_u64()
         );
+
+        assert_eq!(session_id.sub_id(), 0);
+
         // todo - should check sender.id == self?
         let vandermonde_matrix = make_vandermonde(self.n_parties, self.n_parties - 1)?;
         // Implementation of Step 1.
@@ -219,7 +233,7 @@ where
         let r_deg_2t = apply_vandermonde(&vandermonde_matrix, &shares_deg_2t)?;
 
         // Save the shares of r of degree t and 2t into the storage.
-        let bind_store = self.get_or_create_store(session_id).await;
+        let bind_store = self.get_or_create_store(session_id).await?;
         let mut store = bind_store.lock().await;
         store.computed_r_shares_degree_t = r_deg_t.clone();
         store.computed_r_shares_degree_2t = r_deg_2t.clone();
@@ -274,6 +288,11 @@ where
             msg.session_id.as_u64(),
             msg.sender_id
         );
+
+        if msg.session_id.sub_id() != 0 {
+            return Err(RanDouShaError::SessionIdError(msg.session_id));
+        }
+
         let payload = match msg.payload {
             RanDouShaPayload::Reconstruct(p) => p,
             RanDouShaPayload::Output(_) => return Err(RanDouShaError::Abort),
@@ -286,7 +305,7 @@ where
         // one for degree t and one for degree 2t.
         // These shares originate from the *sender* of the message, but they are components of the 'r_j'
 
-        let binding = self.get_or_create_store(msg.session_id).await;
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
 
         store.state = RanDouShaState::Reconstruction;
@@ -377,7 +396,7 @@ where
         if !output {
             return Err(RanDouShaError::Abort);
         }
-        let binding = self.get_or_create_store(msg.session_id).await;
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
 
         store.state = RanDouShaState::Output;
@@ -434,6 +453,107 @@ where
                 self.reconstruction_handler(msg, network).await?;
                 return Ok(());
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::rbc::rbc::Avid;
+    use crate::honeybadger::ran_dou_sha::messages::{RanDouShaMessage, RanDouShaMessageType, RanDouShaPayload, ReconstructionMessage};
+    use crate::honeybadger::SessionId;
+    use ark_bls12_381::Fr;
+    use ark_serialize::CanonicalSerialize;
+    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use stoffelmpc_network::fake_network::{FakeNetwork, FakeNetworkConfig};
+
+    #[tokio::test]
+    async fn test_randousha_storage_limit_in_reconstruction_handler() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanDouShaNode::<Fr, Avid>::new(0, tx, 5, 1, 2).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Fill up the storage to the limit by calling reconstruction_handler with unique session IDs
+        let mut exec = 0u8;
+        let mut round = 0u8;
+        for _ in 0..super::MAX_RAN_DOU_SHA_SESSIONS {
+            let sid = SessionId::new(
+                ProtocolType::Randousha,
+                exec,
+                0,
+                round,
+                111,
+            );
+            let rec_msg = ReconstructionMessage::<Fr>::new(Default::default(), Default::default());
+            let mut payload = Vec::new();
+            rec_msg.serialize_compressed(&mut payload).unwrap();
+            let msg = RanDouShaMessage::new(
+                0,
+                RanDouShaMessageType::ReconstructMessage,
+                sid,
+                RanDouShaPayload::Reconstruct(payload),
+            );
+            // Ignore the result, just fill up storage
+            let _ = node.reconstruction_handler(msg, net.clone()).await;
+
+            // Increment exec and round to ensure unique session IDs
+            if round == u8::MAX {
+                round = 0;
+                exec = exec.wrapping_add(1);
+            } else {
+                round = round.wrapping_add(1);
+            }
+        }
+
+        // Now try to process a message that would require a new session (should hit the limit)
+        let over_sid = SessionId::new(
+            ProtocolType::Randousha,
+            255,
+            0,
+            255,
+            0,
+        );
+        let rec_msg = ReconstructionMessage::<Fr>::new(Default::default(), Default::default());
+        let mut payload = Vec::new();
+        rec_msg.serialize_compressed(&mut payload).unwrap();
+        let msg = RanDouShaMessage::new(
+            0,
+            RanDouShaMessageType::ReconstructMessage,
+            over_sid,
+            RanDouShaPayload::Reconstruct(payload),
+        );
+
+        let result = node.reconstruction_handler(msg, net).await;
+        assert!(matches!(result, Err(RanDouShaError::LimitError)), "Should error on exceeding storage limit");
+    }
+
+    #[tokio::test]
+    async fn test_randousha_handle_invalid_sub_id() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanDouShaNode::<Fr, Avid>::new(0, tx, 5, 1, 2).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Create a session id with sub_id != 0
+        let session_id = SessionId::new(crate::honeybadger::ProtocolType::Randousha, 0, 1, 0, 0);
+
+        // Create a dummy payload
+        let rec_msg = ReconstructionMessage::<Fr>::new(Default::default(), Default::default());
+        let mut payload = Vec::new();
+        rec_msg.serialize_compressed(&mut payload).unwrap();
+        let msg = RanDouShaMessage::new(
+            0,
+            RanDouShaMessageType::ReconstructMessage,
+            session_id,
+            RanDouShaPayload::Reconstruct(payload),
+        );
+
+        // Should return a SessionIdError due to sub_id != 0
+        let result = node.reconstruction_handler(msg, net).await;
+        match result {
+            Err(RanDouShaError::SessionIdError(sid)) => assert_eq!(sid, session_id),
+            _ => panic!("Expected SessionIdError for invalid sub_id"),
         }
     }
 }

--- a/mpc/src/honeybadger/share_gen/mod.rs
+++ b/mpc/src/honeybadger/share_gen/mod.rs
@@ -41,6 +41,10 @@ pub enum RanShaError {
     Abort,
     #[error("waiting for more confirmations")]
     WaitForOk,
+    #[error("session ID {0:?} malformed")]
+    SessionIdError(SessionId),
+    #[error("limit reached")]
+    LimitError
 }
 
 #[derive(Clone, Debug)]

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -31,6 +31,8 @@ pub struct RanShaNode<F: FftField, R: RBC> {
     pub output_sender: Sender<SessionId>,
 }
 
+pub static MAX_SHARE_GEN_SESSIONS: usize = 1024;
+
 impl<F, R> RanShaNode<F, R>
 where
     F: FftField,
@@ -57,12 +59,17 @@ where
     pub async fn get_or_create_store(
         &mut self,
         session_id: SessionId,
-    ) -> Arc<Mutex<RanShaStore<F>>> {
+    ) -> Result<Arc<Mutex<RanShaStore<F>>>, RanShaError> {
         let mut storage = self.store.lock().await;
-        storage
+
+        if storage.len() == MAX_SHARE_GEN_SESSIONS {
+            return Err(RanShaError::LimitError);
+        }
+
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(RanShaStore::empty(self.n_parties))))
-            .clone()
+            .clone())
     }
 
     pub async fn init<N, G>(
@@ -77,6 +84,9 @@ where
     {
         info!("Receiving init for share from {0:?}", self.id);
 
+        assert_eq!(session_id.sub_id(), 0);
+
+        let storage_access = self.get_or_create_store(session_id).await?;
         let secret = F::rand(rng);
 
         let shares_deg_t =
@@ -101,7 +111,6 @@ where
         }
 
         // Update the state of the protocol to Initialized.
-        let storage_access = self.get_or_create_store(session_id).await;
         let mut storage = storage_access.lock().await;
         storage.state = RanShaState::Initialized;
         Ok(())
@@ -115,6 +124,10 @@ where
     where
         N: Network,
     {
+        if msg.session_id.sub_id() != 0 {
+            return Err(RanShaError::SessionIdError(msg.session_id));
+        }
+
         let payload = match msg.payload {
             RanShaPayload::Share(s) => s,
             _ => return Err(RanShaError::Abort),
@@ -123,7 +136,7 @@ where
         let share: ShamirShare<F, 1, Robust> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
 
-        let binding = self.get_or_create_store(msg.session_id).await;
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut ransha_storage = binding.lock().await;
         ransha_storage.initial_shares.insert(msg.sender_id, share);
         info!(
@@ -171,10 +184,11 @@ where
             "party {:?} received shares for Random sharing generation",
             self.id
         );
+
         let vandermonde_matrix = make_vandermonde(self.n_parties, self.n_parties - 1)?;
         let r_deg_t = apply_vandermonde(&vandermonde_matrix, &shares_deg_t)?;
 
-        let bind_store = self.get_or_create_store(session_id).await;
+        let bind_store = self.get_or_create_store(session_id).await?;
         let mut store = bind_store.lock().await;
         store.computed_r_shares = r_deg_t.clone();
         drop(store);
@@ -210,12 +224,16 @@ where
             _ => return Err(RanShaError::Abort),
         };
 
+        if msg.session_id.sub_id() != 0 {
+            return Err(RanShaError::SessionIdError(msg.session_id));
+        }
+
         let share: ShamirShare<F, 1, Robust> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
         if share.degree != self.threshold {
             return Err(RanShaError::ShareError(ShareError::DegreeMismatch));
         }
-        let binding = self.get_or_create_store(msg.session_id).await;
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
         store.state = RanShaState::Reconstruction;
         store.received_r_shares.insert(msg.sender_id, share.clone());
@@ -267,7 +285,11 @@ where
             return Err(RanShaError::Abort);
         }
 
-        let binding = self.get_or_create_store(msg.session_id).await;
+        if msg.session_id.sub_id() != 0 {
+            return Err(RanShaError::SessionIdError(msg.session_id));
+        }
+
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
         store.state = RanShaState::Output;
 
@@ -308,6 +330,282 @@ where
                 self.reconstruction_handler(msg, network).await?;
                 Ok(())
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::rbc::rbc::Avid;
+    use crate::honeybadger::share_gen::{RanShaMessage, RanShaMessageType, RanShaPayload};
+    use crate::honeybadger::SessionId;
+    use ark_bls12_381::Fr;
+    use ark_serialize::CanonicalSerialize;
+    use tokio::sync::mpsc;
+    use std::sync::Arc;
+    use stoffelmpc_network::fake_network::{FakeNetwork, FakeNetworkConfig};
+    use crate::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
+
+    #[tokio::test]
+    async fn test_sharegen_storage_limit_in_receive_shares_handler() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Fill up the storage to the limit by calling receive_shares_handler with unique session IDs
+        let mut exec = 0u8;
+        let mut round = 0u8;
+        for _ in 0..super::MAX_SHARE_GEN_SESSIONS {
+            let sid = SessionId::new(
+                ProtocolType::Ransha,
+                exec,
+                0,
+                round,
+                0,
+            );
+            let share = RobustShare::new(Fr::from(1u8), 0, 1);
+            let mut payload = Vec::new();
+            share.serialize_compressed(&mut payload).unwrap();
+            let msg = RanShaMessage::new(
+                0,
+                RanShaMessageType::ShareMessage,
+                sid,
+                RanShaPayload::Share(payload),
+            );
+            // Ignore the result, just fill up storage
+            let _ = node.receive_shares_handler(msg, net.clone()).await;
+
+            // Increment exec and round to ensure unique session IDs
+            if round == u8::MAX {
+                round = 0;
+                exec = exec.wrapping_add(1);
+            } else {
+                round = round.wrapping_add(1);
+            }
+        }
+
+        // Now try to process a message that would require a new session (should hit the limit)
+        let over_sid = SessionId::new(
+            ProtocolType::Ransha,
+            255,
+            0,
+            255,
+            0,
+        );
+        let share = RobustShare::new(Fr::from(1u8), 0, 1);
+        let mut payload = Vec::new();
+        share.serialize_compressed(&mut payload).unwrap();
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::ShareMessage,
+            over_sid,
+            RanShaPayload::Share(payload),
+        );
+
+        let result = node.receive_shares_handler(msg, net).await;
+        assert!(matches!(result, Err(RanShaError::LimitError)), "Should error on exceeding storage limit");
+    }
+
+    #[tokio::test]
+    async fn test_sharegen_storage_limit_in_reconstruction_handler() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Fill up the storage to the limit by calling reconstruction_handler with unique session IDs
+        let mut exec = 0u8;
+        let mut round = 0u8;
+        for _ in 0..super::MAX_SHARE_GEN_SESSIONS {
+            let sid = SessionId::new(
+                ProtocolType::Ransha,
+                exec,
+                0,
+                round,
+                0,
+            );
+            let share = RobustShare::new(Fr::from(1u8), 0, 1);
+            let mut payload = Vec::new();
+            share.serialize_compressed(&mut payload).unwrap();
+            let msg = RanShaMessage::new(
+                0,
+                RanShaMessageType::ReconstructMessage,
+                sid,
+                RanShaPayload::Reconstruct(payload),
+            );
+            // Ignore the result, just fill up storage
+            let _ = node.reconstruction_handler(msg, net.clone()).await;
+
+            // Increment exec and round to ensure unique session IDs
+            if round == u8::MAX {
+                round = 0;
+                exec = exec.wrapping_add(1);
+            } else {
+                round = round.wrapping_add(1);
+            }
+        }
+
+        // Now try to process a message that would require a new session (should hit the limit)
+        let over_sid = SessionId::new(
+            ProtocolType::Ransha,
+            255,
+            0,
+            255,
+            0,
+        );
+        let share = RobustShare::new(Fr::from(1u8), 0, 1);
+        let mut payload = Vec::new();
+        share.serialize_compressed(&mut payload).unwrap();
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::ReconstructMessage,
+            over_sid,
+            RanShaPayload::Reconstruct(payload),
+        );
+
+        let result = node.reconstruction_handler(msg, net).await;
+        assert!(matches!(result, Err(RanShaError::LimitError)), "Should error on exceeding storage limit");
+    }
+
+    #[tokio::test]
+    async fn test_sharegen_storage_limit_in_output_handler() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+
+        // Fill up the storage to the limit by calling output_handler with unique session IDs
+        let mut exec = 0u8;
+        let mut round = 0u8;
+        for _ in 0..super::MAX_SHARE_GEN_SESSIONS {
+            let sid = SessionId::new(
+                ProtocolType::Ransha,
+                exec,
+                0,
+                round,
+                0,
+            );
+            let msg = RanShaMessage::new(
+                0,
+                RanShaMessageType::OutputMessage,
+                sid,
+                RanShaPayload::Output(true),
+            );
+            // Ignore the result, just fill up storage
+            let _ = node.output_handler(msg).await;
+
+            // Increment exec and round to ensure unique session IDs
+            if round == u8::MAX {
+                round = 0;
+                exec = exec.wrapping_add(1);
+            } else {
+                round = round.wrapping_add(1);
+            }
+        }
+
+        // Now try to process a message that would require a new session (should hit the limit)
+        let over_sid = SessionId::new(
+            ProtocolType::Ransha,
+            255,
+            0,
+            255,
+            0,
+        );
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::OutputMessage,
+            over_sid,
+            RanShaPayload::Output(true),
+        );
+
+        let result = node.output_handler(msg).await;
+        assert!(matches!(result, Err(RanShaError::LimitError)), "Should error on exceeding storage limit");
+    }
+
+    #[tokio::test]
+    async fn test_sharegen_receive_shares_handler_invalid_sub_id() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Create a session id with sub_id != 0
+        let session_id = SessionId::new(
+            ProtocolType::Ransha,
+            0,
+            1,
+            0,
+            0,
+        );
+        let share = RobustShare::new(Fr::from(1u8), 0, 1);
+        let mut payload = Vec::new();
+        share.serialize_compressed(&mut payload).unwrap();
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::ShareMessage,
+            session_id,
+            RanShaPayload::Share(payload),
+        );
+
+        let result = node.receive_shares_handler(msg, net).await;
+        match result {
+            Err(RanShaError::SessionIdError(sid)) => assert_eq!(sid, session_id),
+            _ => panic!("Expected SessionIdError for invalid sub_id"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sharegen_reconstruction_handler_invalid_sub_id() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+
+        // Create a session id with sub_id != 0
+        let session_id = SessionId::new(
+            ProtocolType::Ransha,
+            0,
+            1,
+            0,
+            0,
+        );
+        let share = RobustShare::new(Fr::from(1u8), 0, 1);
+        let mut payload = Vec::new();
+        share.serialize_compressed(&mut payload).unwrap();
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::ReconstructMessage,
+            session_id,
+            RanShaPayload::Reconstruct(payload),
+        );
+
+        let result = node.reconstruction_handler(msg, net).await;
+        match result {
+            Err(RanShaError::SessionIdError(sid)) => assert_eq!(sid, session_id),
+            _ => panic!("Expected SessionIdError for invalid sub_id"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sharegen_output_handler_invalid_sub_id() {
+        let (tx, _rx) = mpsc::channel(1);
+        let mut node = RanShaNode::<Fr, Avid>::new(0, 5, 1, 2, tx).unwrap();
+
+        // Create a session id with sub_id != 0
+        let session_id = SessionId::new(
+            ProtocolType::Ransha,
+            0,
+            1,
+            0,
+            0,
+        );
+        let msg = RanShaMessage::new(
+            0,
+            RanShaMessageType::OutputMessage,
+            session_id,
+            RanShaPayload::Output(true),
+        );
+
+        let result = node.output_handler(msg).await;
+        match result {
+            Err(RanShaError::SessionIdError(sid)) => assert_eq!(sid, session_id),
+            _ => panic!("Expected SessionIdError for invalid sub_id"),
         }
     }
 }

--- a/mpc/src/honeybadger/triple_gen/mod.rs
+++ b/mpc/src/honeybadger/triple_gen/mod.rs
@@ -51,6 +51,10 @@ pub enum TripleGenError {
     SessionIdMismatch,
     #[error("error sending the thread asynchronously")]
     SendError(#[from] SendError<SessionId>),
+    #[error("session ID {0:?} malformed")]
+    SessionIdError(SessionId),
+    #[error("limit reached")]
+    LimitError
 }
 
 /// Represents a Beaver triple of non-robust Shamir shares.

--- a/mpc/src/honeybadger/triple_gen/triple_generation.rs
+++ b/mpc/src/honeybadger/triple_gen/triple_generation.rs
@@ -47,6 +47,8 @@ where
     pub batch_recon_node: BatchReconNode<F>,
 }
 
+pub static MAX_TRIPLE_GEN_SESSIONS: usize = 1024;
+
 impl<F> TripleGenNode<F>
 where
     F: FftField,
@@ -74,12 +76,17 @@ where
     pub async fn get_or_create_store(
         &mut self,
         session_id: SessionId,
-    ) -> Arc<Mutex<TripleGenStorage<F>>> {
+    ) -> Result<Arc<Mutex<TripleGenStorage<F>>>, TripleGenError> {
         let mut storage = self.storage.lock().await;
-        storage
+
+        if storage.len() == MAX_TRIPLE_GEN_SESSIONS {
+            return Err(TripleGenError::LimitError);
+        }
+
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(TripleGenStorage::empty())))
-            .clone()
+            .clone())
     }
 
     /// Initializes the protocol to generate random triples based on previously generated shares
@@ -102,6 +109,8 @@ where
             "Initializing TripleGen protocol"
         );
 
+        assert_eq!(session_id.sub_id(), 0);
+
         if randousha_pairs.len() != 2 * self.threshold + 1
             || random_shares_a.len() != 2 * self.threshold + 1
             || random_shares_b.len() != 2 * self.threshold + 1
@@ -121,7 +130,7 @@ where
 
         // We mark the protocol as initialized and store the input shares.
         {
-            let storage_bind = self.get_or_create_store(session_id).await;
+            let storage_bind = self.get_or_create_store(session_id).await?;
             let mut storage = storage_bind.lock().await;
             storage.protocol_state = ProtocolState::Initialized;
             storage.randousha_pairs = randousha_pairs;
@@ -148,7 +157,13 @@ where
         let batch_recon_result: Vec<F> =
             CanonicalDeserialize::deserialize_compressed(message.payload.as_slice())?;
 
-        let storage_bind = self.get_or_create_store(message.session_id).await;
+        // SHOULD NEVER HAPPEN, since comes from batch reconstruction
+        if message.session_id.sub_id() != 0 {
+            return Err(TripleGenError::SessionIdError(message.session_id));
+        }
+
+        // SHOULD ALSO NEVER FAIL, since comes from batch reconstruction
+        let storage_bind = self.get_or_create_store(message.session_id).await?;
         let mut storage = storage_bind.lock().await;
 
         let mut result_triples = Vec::new();

--- a/mpc/tests/node_test.rs
+++ b/mpc/tests/node_test.rs
@@ -80,7 +80,8 @@ async fn randousha_e2e() {
                 .preprocess
                 .ran_dou_sha
                 .get_or_create_store(session_id)
-                .await;
+                .await
+                .unwrap();
 
             loop {
                 let store = store.lock().await;
@@ -136,7 +137,8 @@ async fn ransha_e2e() {
                 .preprocess
                 .share_gen
                 .get_or_create_store(session_id)
-                .await;
+                .await
+                .unwrap();
 
             loop {
                 let store = store.lock().await;
@@ -282,7 +284,8 @@ async fn gen_masks_for_input_e2e() {
                 .preprocess
                 .share_gen
                 .get_or_create_store(session_id)
-                .await;
+                .await
+                .unwrap();
 
             loop {
                 let store = store.lock().await;
@@ -303,7 +306,8 @@ async fn gen_masks_for_input_e2e() {
             .preprocess
             .share_gen
             .get_or_create_store(session_id)
-            .await;
+            .await
+            .unwrap();
         let local_shares = local_store.lock().await.protocol_output.clone();
         match node
             .preprocess
@@ -993,6 +997,79 @@ async fn preprocessing_e2e() {
         assert_eq!(n_shares, 2); //>no_of_randomshares
         assert_eq!(n_prandbit, 4);
         assert_eq!(n_prandint, 4);
+    }
+}
+
+#[tokio::test] #[ignore]    // ignored since it takes a long time
+async fn preprocessing_e2e_big() {
+    setup_tracing();
+    //----------------------------------------SETUP PARAMETERS----------------------------------------
+    let n_parties = 5;
+    let t = 1;
+    let l = 8;
+    let k = 4;
+    let no_of_triples = 20000;
+    let no_of_randomshares = 20000;
+    let instance_id = 111;
+    let n_prandbit = 0;
+    let n_prandint = 0;
+
+    //Setup
+    let (network, receivers, _) = test_setup(n_parties, vec![]);
+
+    //----------------------------------------SETUP NODES----------------------------------------
+    // create global nodes
+    let nodes = create_global_nodes::<Fr, Avid, RobustShare<Fr>, FakeNetwork>(
+        n_parties,
+        t,
+        no_of_triples,
+        no_of_randomshares,
+        instance_id,
+        n_prandbit,
+        n_prandint,
+        l,
+        k,
+        vec![]
+    );
+
+    //----------------------------------------RECIEVE----------------------------------------
+    // spawn tasks to process received messages
+    receive::<Fr, Avid, RobustShare<Fr>, FakeNetwork>(receivers, nodes.clone(), network.clone());
+
+    //----------------------------------------RUN PROTOCOL----------------------------------------
+
+    // init all nodes
+    let mut handles = Vec::new();
+    for pid in 0..n_parties {
+        let mut node = nodes[pid].clone();
+        let net = network.clone();
+        let mut rng = StdRng::from_rng(OsRng).unwrap();
+
+        let handle = tokio::spawn(async move {
+            {
+                node.run_preprocessing(net, &mut rng)
+                    .await
+                    .expect("Preprocessing failed");
+            }
+        });
+        handles.push(handle);
+    }
+
+    // Wait for all mul tasks to finish
+    futures::future::join_all(handles).await;
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    //----------------------------------------VALIDATE VALUES----------------------------------------
+
+    for pid in 0..n_parties {
+        let node = nodes[pid].clone();
+        let (n_triples, n_shares, n_prandbit, n_prandint) =
+            node.preprocessing_material.lock().await.len();
+        info!("{}: {} {}", pid, n_triples, n_shares);
+        assert_eq!(n_triples, 20000); //>no_of_triples
+        assert_eq!(n_shares, 20000); //>no_of_randomshares
+        assert_eq!(n_prandbit, 0);
+        assert_eq!(n_prandint, 0);
     }
 }
 

--- a/mpc/tests/randousha_test.rs
+++ b/mpc/tests/randousha_test.rs
@@ -96,6 +96,7 @@ async fn test_init_reconstruct_flow() {
             .clone()
             .get_or_create_store(session_id)
             .await
+            .unwrap()
             .lock()
             .await
             .clone();
@@ -214,6 +215,7 @@ async fn test_reconstruct_handler() {
     let store = randousha_node
         .get_or_create_store(session_id)
         .await
+        .unwrap()
         .lock()
         .await
         .clone();
@@ -325,6 +327,7 @@ async fn test_reconstruct_handler_mismatch_r_t_2t() {
     let store = randousha_node
         .get_or_create_store(session_id)
         .await
+        .unwrap()
         .lock()
         .await
         .clone();
@@ -362,7 +365,7 @@ async fn test_output_handler() {
         .await
         .unwrap();
 
-    let node_store = randousha_node.get_or_create_store(session_id).await;
+    let node_store = randousha_node.get_or_create_store(session_id).await.unwrap();
 
     // first n-(t+1)-1 message should return error
     for i in 0..n_parties - (threshold + 2) {
@@ -421,7 +424,7 @@ async fn test_output_handler() {
         .await
         .expect("output handler should not fail");
     {
-        let storage_mutex = randousha_node.get_or_create_store(session_id).await;
+        let storage_mutex = randousha_node.get_or_create_store(session_id).await.unwrap();
         let storage = storage_mutex.lock().await;
         let output = storage.protocol_output.clone();
 
@@ -506,7 +509,7 @@ async fn randousha_e2e() {
 
     for nodes in &randousha_nodes {
         let mut node_locked = nodes.lock().await;
-        let store = node_locked.get_or_create_store(session_id).await;
+        let store = node_locked.get_or_create_store(session_id).await.unwrap();
         let store_locked = store.lock().await;
         assert!(store_locked.state == RanDouShaState::Finished);
     }

--- a/mpc/tests/ransha_test.rs
+++ b/mpc/tests/ransha_test.rs
@@ -129,6 +129,7 @@ async fn test_reconstruct_handler_incorrect_share() {
         .share_gen
         .get_or_create_store(session_id)
         .await
+        .unwrap()
         .lock()
         .await
         .clone();
@@ -163,7 +164,7 @@ async fn test_output_handler() {
         .await
         .unwrap();
 
-    let node_store = ransha_node.get_or_create_store(session_id).await;
+    let node_store = ransha_node.get_or_create_store(session_id).await.unwrap();
 
     // first 2t-1 message should return error
     for i in 0..(2 * threshold - 1) {


### PR DESCRIPTION
Limits on the number of times a subprotocol can be executed as well as on other protocol-specific resources such as storage are set.

Related to that, session IDs are checked to minimize the target surface for malicious messages.
This means
	- protocol-specific checks such as sub ID == 0
	- check that instance ID matches the one of the current instance

To test session IDs, a preprocessing test with a lot of shares and triples has been added.