### PR TITLE
Update stoffelnet dependency and implement new Network trait methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace.dependencies]
-stoffelnet = { git = "https://github.com/Stoffel-Labs/stoffel-networking.git", rev = "bac0841120d7e99f6be867a00dd3c38a6fc5f126" }
+stoffelnet = { git = "https://github.com/Stoffel-Labs/stoffel-networking.git", branch = "feature/sto-337-cratesio-prep" }
 ark-ff = { version = "0.5.0", features = [ "asm" ] }
 ark-poly = "0.5.0"
 tokio = { version = "1.46.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ async fn test_mul() {
 
     // ---------------- Network ----------------
     let config = FakeNetworkConfig::new(500);
-    let (network, receivers, _) = FakeNetwork::new(n, Some(vec![]), config);
+    let (network, receivers, _) = FakeNetwork::new(n, Some(vec![]), config, 0);
     let network: Arc<FakeNetwork> = Arc::new(network);
 
     // ---------------- Inputs ----------------

--- a/mpc/src/ffi/c_bindings/network/fake_network.rs
+++ b/mpc/src/ffi/c_bindings/network/fake_network.rs
@@ -40,7 +40,7 @@ pub extern "C" fn new_fake_network(
         }
     };
 
-    let (network, node_receivers, client_receivers) = FakeNetwork::new(n_nodes, n_clients, config);
+    let (network, node_receivers, client_receivers) = FakeNetwork::new(n_nodes, n_clients, config, 0);
     // return the receivers
     let receivers = FakeNetworkReceivers {
         node_receivers,

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -482,7 +482,7 @@ pub mod tests {
 
         let config = FakeNetworkConfig::new(500);
         let (network, mut receivers, mut client_recv_map) =
-            FakeNetwork::new(n, Some(vec![clientid]), config);
+            FakeNetwork::new(n, Some(vec![clientid]), config, 0);
         let mut client_recv = client_recv_map.remove(&clientid).unwrap();
         let network = Arc::new(network);
 

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -656,7 +656,7 @@ pub mod tests {
         }
 
         let config = FakeNetworkConfig::new(500);
-        let (network, mut receivers, _) = FakeNetwork::new(n, None, config);
+        let (network, mut receivers, _) = FakeNetwork::new(n, None, config, 0);
         let network = Arc::new(network);
 
         let mut nodes: Vec<_> = (0..n)

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -514,7 +514,7 @@ mod tests {
     #[tokio::test]
     async fn test_randousha_storage_limit_in_reconstruction_handler() {
         let mut node = RanDouShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Fill up the storage to the limit by calling reconstruction_handler with unique session IDs
         let mut exec = 0u8;
@@ -572,7 +572,7 @@ mod tests {
     #[tokio::test]
     async fn test_randousha_handle_invalid_sub_id() {
         let mut node = RanDouShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Create a session id with sub_id != 0
         let session_id =

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -408,7 +408,7 @@ mod tests {
     #[tokio::test]
     async fn test_sharegen_storage_limit_in_receive_shares_handler() {
         let mut node = RanShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Fill up the storage to the limit by calling receive_shares_handler with unique session IDs
         let mut exec = 0u8;
@@ -462,7 +462,7 @@ mod tests {
     #[tokio::test]
     async fn test_sharegen_storage_limit_in_reconstruction_handler() {
         let mut node = RanShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Fill up the storage to the limit by calling reconstruction_handler with unique session IDs
         let mut exec = 0u8;
@@ -563,7 +563,7 @@ mod tests {
     #[tokio::test]
     async fn test_sharegen_receive_shares_handler_invalid_sub_id() {
         let mut node = RanShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Create a session id with sub_id != 0
         let session_id = SessionId::new(ProtocolType::Ransha, SessionId::pack_slot24(0, 1, 0), 0);
@@ -587,7 +587,7 @@ mod tests {
     #[tokio::test]
     async fn test_sharegen_reconstruction_handler_invalid_sub_id() {
         let mut node = RanShaNode::<Fr, Avid<SessionId>>::new(0, 5, 1, 2).unwrap();
-        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10)).0);
+        let net = Arc::new(FakeNetwork::new(5, None, FakeNetworkConfig::new(10), 0).0);
 
         // Create a session id with sub_id != 0
         let session_id = SessionId::new(ProtocolType::Ransha, SessionId::pack_slot24(0, 1, 0), 0);

--- a/mpc/tests/batchrecon_test.rs
+++ b/mpc/tests/batchrecon_test.rs
@@ -127,7 +127,7 @@ mod tests {
             111,
         );
         let config = FakeNetworkConfig::new(100);
-        let (network, mut receivers, _) = FakeNetwork::new(n, None, config);
+        let (network, mut receivers, _) = FakeNetwork::new(n, None, config, 0);
         let net = Arc::new(network);
 
         let secrets: Vec<Fr> = vec![Fr::from(3u64), Fr::from(6u64)];

--- a/mpc/tests/utils/test_utils.rs
+++ b/mpc/tests/utils/test_utils.rs
@@ -40,7 +40,7 @@ pub async fn setup_network_and_parties<T: RBC<Id = SessionId>, N: Network>(
     buffer_size: usize,
 ) -> Result<(Vec<T>, Arc<FakeNetwork>, Vec<mpsc::Receiver<Vec<u8>>>), RbcError> {
     let config = FakeNetworkConfig::new(buffer_size);
-    let (network, receivers, _) = FakeNetwork::new(n as usize, None, config);
+    let (network, receivers, _) = FakeNetwork::new(n as usize, None, config, 0);
     let net = Arc::new(network);
 
     let mut parties = Vec::with_capacity(n as usize);
@@ -97,7 +97,7 @@ pub fn test_setup(
     HashMap<usize, Receiver<Vec<u8>>>,
 ) {
     let config = FakeNetworkConfig::new(500);
-    let (network, receivers, client_recv) = FakeNetwork::new(n, Some(clientid), config);
+    let (network, receivers, client_recv) = FakeNetwork::new(n, Some(clientid), config, 0);
     let network = Arc::new(network);
     (network, receivers, client_recv)
 }
@@ -114,7 +114,7 @@ pub fn test_setup_bad(
 ) {
     let config = BadFakeNetworkConfig::new(500);
     let (network, net_rx, node_channels, receivers, client_recv) =
-        BadFakeNetwork::new(n, Some(clientid), config);
+        BadFakeNetwork::new(n, Some(clientid), config, 0);
     let network = Arc::new(network);
     (network, net_rx, node_channels, receivers, client_recv)
 }

--- a/network/src/bad_fake_network.rs
+++ b/network/src/bad_fake_network.rs
@@ -159,10 +159,13 @@ pub struct BadFakeNetwork {
     nodes: Vec<FakeBadNode>,
     /// Channels to send messages to clients.
     client_channels: HashMap<ClientId, Sender<Vec<u8>>>,
+    /// The local party id (for trait implementation - shared networks use 0).
+    local_id: PartyId,
 }
 
 impl BadFakeNetwork {
     /// Creates a new bad fake network for testing using the given number of nodes and configuration.
+    /// The `local_id` parameter is used for the trait implementation - shared networks typically use 0.
     /// Returns
     ///   1. a receiving endpoint to receive messages sent by nodes at the delaying thread
     ///   2. sending endpoints to deliver messages to nodes from the delaying thread, connected to
@@ -176,6 +179,7 @@ impl BadFakeNetwork {
         n_nodes: usize,
         n_clients: Option<Vec<ClientId>>,
         config: BadFakeNetworkConfig,
+        local_id: PartyId,
     ) -> (
         Self,
         Receiver<(PartyId, Vec<u8>)>,
@@ -215,6 +219,7 @@ impl BadFakeNetwork {
                 config,
                 nodes,
                 client_channels: client_channels.clone(),
+                local_id,
             },
             net_rx,
             node_channels,
@@ -386,6 +391,14 @@ impl Network for BadFakeNetwork {
     fn is_client_connected(&self, client: ClientId) -> bool {
         self.client_channels.contains_key(&client)
     }
+
+    fn local_party_id(&self) -> PartyId {
+        self.local_id
+    }
+
+    fn party_count(&self) -> usize {
+        self.nodes.len()
+    }
 }
 
 /// Represents a node in the BadFakeNetwork.
@@ -444,7 +457,7 @@ mod tests {
 
         let n_nodes = 5;
         let config = BadFakeNetworkConfig::new(100);
-        let (network, _, _, _, _) = BadFakeNetwork::new(n_nodes, None, config);
+        let (network, _, _, _, _) = BadFakeNetwork::new(n_nodes, None, config, 0);
 
         let channels = network.net_channels.clone();
 
@@ -465,7 +478,7 @@ mod tests {
         let n_nodes = 3;
         let config = BadFakeNetworkConfig::new(100);
         let (network, net_rx, node_channels, mut receivers, _) =
-            BadFakeNetwork::new(n_nodes, None, config);
+            BadFakeNetwork::new(n_nodes, None, config, 0);
 
         BadFakeNetwork::start(
             net_rx,
@@ -509,7 +522,7 @@ mod tests {
         let n_nodes = 3;
         let config = BadFakeNetworkConfig::new(100);
         let (network, net_rx, node_channels, mut receivers, _) =
-            BadFakeNetwork::new(n_nodes, None, config);
+            BadFakeNetwork::new(n_nodes, None, config, 0);
         let network = Arc::new(Mutex::new(network));
 
         BadFakeNetwork::start(
@@ -558,7 +571,7 @@ mod tests {
 
         let n_nodes = 2;
         let config = BadFakeNetworkConfig::new(100);
-        let (mut network, net_rx, node_channels, _, _) = BadFakeNetwork::new(n_nodes, None, config);
+        let (mut network, net_rx, node_channels, _, _) = BadFakeNetwork::new(n_nodes, None, config, 0);
 
         BadFakeNetwork::start(
             net_rx,
@@ -601,7 +614,7 @@ mod tests {
         let n_nodes = 2;
         let config = BadFakeNetworkConfig::new(500);
         let (network, net_rx, node_channels, mut receivers, _) =
-            BadFakeNetwork::new(n_nodes, None, config);
+            BadFakeNetwork::new(n_nodes, None, config, 0);
 
         BadFakeNetwork::start(
             net_rx,

--- a/network/src/fake_network.rs
+++ b/network/src/fake_network.rs
@@ -16,15 +16,19 @@ pub struct FakeNetwork {
     nodes: Vec<FakeNode>,
     /// Channels to send messages to clients.
     client_channels: HashMap<ClientId, Sender<Vec<u8>>>,
+    /// The local party id (for trait implementation - shared networks use 0).
+    local_id: PartyId,
 }
 
 impl FakeNetwork {
     /// Creates a new fake network for testing using the given number of nodes and configuration.
+    /// The `local_id` parameter is used for the trait implementation - shared networks typically use 0.
     #[allow(clippy::type_complexity)]
     pub fn new(
         n_nodes: usize,
         n_clients: Option<Vec<ClientId>>,
         config: FakeNetworkConfig,
+        local_id: PartyId,
     ) -> (
         Self,
         Vec<Receiver<Vec<u8>>>,
@@ -56,6 +60,7 @@ impl FakeNetwork {
                 config,
                 nodes,
                 client_channels: client_channels.clone(),
+                local_id,
             },
             receivers,
             client_receivers,
@@ -142,6 +147,14 @@ impl Network for FakeNetwork {
     fn is_client_connected(&self, client: ClientId) -> bool {
         self.client_channels.contains_key(&client)
     }
+
+    fn local_party_id(&self) -> PartyId {
+        self.local_id
+    }
+
+    fn party_count(&self) -> usize {
+        self.nodes.len()
+    }
 }
 
 /// Represents a node in the FakeNetwork.
@@ -197,7 +210,7 @@ mod tests {
     async fn test_fake_network_new() {
         let n_nodes = 5;
         let config = FakeNetworkConfig::new(100);
-        let (network, _, _) = FakeNetwork::new(n_nodes, None, config);
+        let (network, _, _) = FakeNetwork::new(n_nodes, None, config, 0);
 
         let channels = network.node_channels.clone();
 
@@ -215,7 +228,7 @@ mod tests {
     async fn test_fake_network_send_and_receive() {
         let n_nodes = 3;
         let config = FakeNetworkConfig::new(100);
-        let (network, mut receivers, _) = FakeNetwork::new(n_nodes, None, config);
+        let (network, mut receivers, _) = FakeNetwork::new(n_nodes, None, config, 0);
 
         let sender_id = 1;
         let recipient_id = 2;
@@ -247,7 +260,7 @@ mod tests {
     async fn test_fake_network_broadcast() {
         let n_nodes = 3;
         let config = FakeNetworkConfig::new(100);
-        let (network, mut receivers, _) = FakeNetwork::new(n_nodes, None, config);
+        let (network, mut receivers, _) = FakeNetwork::new(n_nodes, None, config, 0);
         let network = Arc::new(Mutex::new(network));
 
         let message = b"broadcast";
@@ -283,7 +296,7 @@ mod tests {
     async fn test_network_error_on_send_failure() {
         let n_nodes = 2;
         let config = FakeNetworkConfig::new(100);
-        let (mut network, _, _) = FakeNetwork::new(n_nodes, None, config);
+        let (mut network, _, _) = FakeNetwork::new(n_nodes, None, config, 0);
 
         let recipient_id = 1;
         let message = b"test";


### PR DESCRIPTION
## Summary
- Updated stoffelnet dependency from revision `bac0841` to branch `feature/sto-337-cratesio-prep`
- Implemented two new required Network trait methods: `local_party_id()` and `party_count()`
- Added `local_id` field to `FakeNetwork` and `BadFakeNetwork` structs
- Updated all call sites to pass the `local_id` parameter (using 0 for shared test networks)
- All tests pass

## Context
This change follows the stoffelnet API update which added these required methods to the Network trait. The `local_party_id()` method allows network implementations to track which party they represent, while `party_count()` provides the total number of parties in the network.

## Changes
- **Cargo.toml**: Updated stoffelnet dependency to use `feature/sto-337-cratesio-prep` branch
- **fake_network.rs**: Added `local_id` field and implemented new trait methods
- **Test files**: Updated all `FakeNetwork` and `BadFakeNetwork` instantiations to pass `local_id` parameter

## Testing
All existing tests pass with the new implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)