### PR TITLE
Veria fixes

### DIFF
--- a/mpc/src/avss_mpc/share_gen/share_gen_avss.rs
+++ b/mpc/src/avss_mpc/share_gen/share_gen_avss.rs
@@ -4,7 +4,12 @@ use crate::{
         AvssSessionId, AvssWrappedMessage,
     },
     common::{
-        share::{apply_vandermonde, avss::AvssNode, feldman::FeldmanShamirShare, make_vandermonde},
+        share::{
+            apply_vandermonde,
+            avss::{AvssError, AvssNode},
+            feldman::FeldmanShamirShare,
+            make_vandermonde,
+        },
         ProtocolSessionId, ShamirShare, RBC,
     },
 };
@@ -202,7 +207,11 @@ where
             for i in 0..n {
                 let a_ki = vandermonde_matrix[k][i]; // field element
                 let ci = &shares_deg_t[i].commitments;
-
+                if ci.len() != t + 1 {
+                    return Err(RanShaAvssError::AvssError(
+                        AvssError::InvalidCommitmentLength,
+                    ));
+                }
                 for j in 0..=t {
                     ck[j] += ci[j].mul(a_ki);
                 }

--- a/mpc/src/common/rbc/rbc.rs
+++ b/mpc/src/common/rbc/rbc.rs
@@ -109,7 +109,6 @@ where
             payload.clone(),
             vec![],
             GenericMsgType::Bracha(MsgType::Init),
-            payload.len(),
         );
         info!(
             id = self.id,
@@ -194,7 +193,6 @@ where
                 msg.payload.clone(),
                 vec![],
                 GenericMsgType::Bracha(MsgType::Echo),
-                msg.payload.len(),
             );
             store.mark_echo(); // Mark that ECHO has been sent.
             info!(
@@ -254,7 +252,6 @@ where
                         msg.payload.clone(),
                         vec![],
                         GenericMsgType::Bracha(MsgType::Ready),
-                        msg.payload.len(),
                     ));
                 }
                 // If ECHO hasn't been sent yet, broadcast the ECHO message.
@@ -267,7 +264,6 @@ where
                         msg.payload.clone(),
                         vec![],
                         GenericMsgType::Bracha(MsgType::Echo),
-                        msg.payload.len(),
                     ));
                 }
             }
@@ -343,7 +339,6 @@ where
                         msg.payload.clone(),
                         vec![],
                         GenericMsgType::Bracha(MsgType::Ready),
-                        msg.payload.clone().len(),
                     ));
                 }
                 // If ECHO hasn't been sent yet, broadcast it along with READY.
@@ -356,7 +351,6 @@ where
                         msg.payload.clone(),
                         vec![],
                         GenericMsgType::Bracha(MsgType::Echo),
-                        msg.payload.len(),
                     ));
                 }
             } else if count >= 2 * self.t + 1 {
@@ -588,7 +582,6 @@ impl<Id: ProtocolSessionId> RBC for Avid<Id> {
                 shard,
                 fp, // [root||fingerprint]
                 GenericMsgType::Avid(MsgTypeAvid::Send),
-                payload.len(),
             );
 
             if let Err(e) = self.send(msg, net.clone(), i).await {
@@ -675,7 +668,6 @@ impl<Id: ProtocolSessionId> Avid<Id> {
                         msg.payload,
                         msg.metadata,
                         GenericMsgType::Avid(MsgTypeAvid::Echo),
-                        msg.msg_len,
                     );
                     store.mark_echo(); // Mark that ECHO has been sent to avoid resending it
                     info!(
@@ -870,14 +862,14 @@ impl<Id: ProtocolSessionId> Avid<Id> {
                     }
 
                     // Final consensus stage: enough READY messages to reconstruct
-                    if ready_count == (self.k + self.t) {
+                    if ready_count >= (self.k + self.t) && !store.ended {
                         let shards = decode_rs(
                             store.get_shards_for_root(&root.to_vec()),
                             self.k,
                             self.n - self.k,
                         )?;
                         //Reconstruct the original message to be broadcasted
-                        let output = reconstruct_payload(shards, msg.msg_len, self.k)?;
+                        let output = reconstruct_payload(shards, self.k)?;
                         store.mark_ended(); //Terminate broadcast
                         store.set_output(output.clone()); //store the output
                         send_output = Some(output);
@@ -999,7 +991,6 @@ impl<Id: ProtocolSessionId> Avid<Id> {
             payload,
             fingerprint,
             GenericMsgType::Avid(MsgTypeAvid::Ready),
-            msg.msg_len,
         );
         info!(
             id = self.id,
@@ -1170,7 +1161,6 @@ impl<Id: ProtocolSessionId + 'static> RBC for ABA<Id> {
             vec![v_r.0 as u8], // [value]
             vec![],
             GenericMsgType::ABA(MsgTypeAba::Est),
-            payload.len(),
         );
 
         // Lock the session store to update the session state.
@@ -1285,7 +1275,6 @@ impl<Id: ProtocolSessionId + 'static> ABA<Id> {
                     msg.payload.clone(),
                     msg.metadata.clone(),
                     GenericMsgType::ABA(MsgTypeAba::Est),
-                    msg.msg_len,
                 );
                 self.broadcast(new_msg, net.clone()).await?;
             }
@@ -1302,7 +1291,6 @@ impl<Id: ProtocolSessionId + 'static> ABA<Id> {
                         msg.payload,
                         msg.metadata,
                         GenericMsgType::ABA(MsgTypeAba::Aux),
-                        msg.msg_len,
                     );
                     drop(store);
                     self.broadcast(new_msg, net).await?;
@@ -1580,7 +1568,6 @@ impl<Id: ProtocolSessionId + 'static> ABA<Id> {
             vec![value as u8],
             msg.metadata.clone(),
             GenericMsgType::ABA(MsgTypeAba::Est),
-            msg.msg_len,
         );
         self.broadcast(msg, net).await?;
         Ok(())
@@ -1650,7 +1637,6 @@ impl<Id: ProtocolSessionId + 'static> ABA<Id> {
             signshare.to_bytes().to_vec(),
             vec![],
             GenericMsgType::ABA(MsgTypeAba::Coin),
-            msg.msg_len,
         );
         info!(
             session_id = msg.session_id.as_u64(),
@@ -1836,7 +1822,6 @@ impl Dealer {
                 serialized_share,
                 pkset_serial.clone(),
                 msg.msg_type.clone(),
-                msg.msg_len,
             );
 
             let encoded = (wrapper)(key_msg)?;

--- a/mpc/src/common/rbc/rbc_store.rs
+++ b/mpc/src/common/rbc/rbc_store.rs
@@ -15,7 +15,6 @@ pub struct Msg<Id: ProtocolSessionId> {
     pub payload: Vec<u8>, // Actual data being broadcasted (e.g., bytes of a secret or message)
     pub metadata: Vec<u8>, // info related to the message shared
     pub msg_type: GenericMsgType, // Type of message like INIT, ECHO, or READY
-    pub msg_len: usize,   // length of the original message
 }
 
 fn hash_message(message: &[u8]) -> Vec<u8> {
@@ -31,7 +30,6 @@ impl<Id: ProtocolSessionId> Msg<Id> {
         payload: Vec<u8>,
         metadata: Vec<u8>,
         msg_type: GenericMsgType,
-        msg_len: usize,
     ) -> Self {
         Msg {
             sender_id,
@@ -40,7 +38,6 @@ impl<Id: ProtocolSessionId> Msg<Id> {
             payload,
             metadata,
             msg_type,
-            msg_len,
         }
     }
 }

--- a/mpc/src/common/rbc/utils.rs
+++ b/mpc/src/common/rbc/utils.rs
@@ -14,18 +14,21 @@ pub fn encode_rs(
     if data_shards == 0 || parity_shards == 0 {
         return Err(ShardError::Config("Shard counts must be > 0".to_string()));
     }
+    let original_len = payload.len() as u64;
+    let mut auth_payload = original_len.to_le_bytes().to_vec();
+    auth_payload.extend_from_slice(&payload);
 
     // Make sure the payload is divisible across data shards
-    let shard_size = (payload.len() + data_shards - 1) / data_shards;
+    let shard_size = (auth_payload.len() + data_shards - 1) / data_shards;
     let mut shards = Vec::with_capacity(data_shards + parity_shards);
 
     // Fill data shards (pad last shard if needed)
     for i in 0..data_shards {
         let start = i * shard_size;
 
-        let shard = if start < payload.len() {
-            let end = usize::min(start + shard_size, payload.len());
-            let mut s = payload[start..end].to_vec();
+        let shard = if start < auth_payload.len() {
+            let end = usize::min(start + shard_size, auth_payload.len());
+            let mut s = auth_payload[start..end].to_vec();
             s.resize(shard_size, 0); // pad if needed
             s
         } else {
@@ -84,7 +87,6 @@ pub fn decode_rs(
 /// Reconstructs the original payload from decoded data shards
 pub fn reconstruct_payload(
     decoded_shards: Vec<Vec<u8>>,
-    original_len: usize,
     data_shards: usize,
 ) -> Result<Vec<u8>, ShardError> {
     if decoded_shards.len() < data_shards {
@@ -96,6 +98,18 @@ pub fn reconstruct_payload(
         .take(data_shards)
         .flatten()
         .collect::<Vec<u8>>();
+    if payload.len() < 8 {
+        return Err(ShardError::Config(
+            "Payload too short for length prefix".to_string(),
+        ));
+    }
+
+    let mut len_bytes = [0u8; 8];
+    len_bytes.copy_from_slice(&payload[0..8]);
+    let original_len = u64::from_le_bytes(len_bytes) as usize;
+
+    payload.drain(0..8);
+
     // Validate and truncate to the original message length
     if original_len > payload.len() {
         return Err(ShardError::Config(
@@ -235,7 +249,7 @@ mod tests {
             decode_rs(shards_map, data_shards, parity_shards).expect("Decoding should succeed");
 
         // Reconstruct payload
-        let reconstructed = reconstruct_payload(decoded_shards, payload.len(), data_shards)
+        let reconstructed = reconstruct_payload(decoded_shards, data_shards)
             .expect("Reconstruction should succeed");
 
         assert_eq!(payload, reconstructed);

--- a/mpc/src/common/share/avss.rs
+++ b/mpc/src/common/share/avss.rs
@@ -80,6 +80,9 @@ where
 pub fn verify_feldman<F: FftField, G: CurveGroup<ScalarField = F>>(
     share: FeldmanShamirShare<F, G>,
 ) -> bool {
+    if share.commitments.len() != share.feldmanshare.degree + 1 {
+        return false;
+    }
     let x = F::from(share.feldmanshare.id as u64);
     let mut rhs = G::zero();
     let mut pow = F::one();
@@ -310,7 +313,10 @@ where
         };
 
         let pk_d: G = CanonicalDeserialize::deserialize_compressed(&msg.dealer_pk[..])?;
-        let cts: &Vec<Vec<u8>> = &msg.encrypted_shares[self.id];
+        let cts: &Vec<Vec<u8>> = msg
+            .encrypted_shares
+            .get(self.id)
+            .ok_or(AvssError::InvalidShare)?;
 
         let ss = pk_d.mul(self.sk_i);
         let key = kdf_from_point(&ss);

--- a/mpc/src/ffi/c_bindings/rbc/mod.rs
+++ b/mpc/src/ffi/c_bindings/rbc/mod.rs
@@ -136,7 +136,6 @@ pub struct RbcMsg {
     pub payload: ByteSlice, // Actual data being broadcasted (e.g., bytes of a secret or message)
     pub metadata: ByteSlice, // info related to the message shared
     pub msg_type: RbcMessageType, // Type of message like INIT, ECHO, or READY
-    pub msg_len: usize,     // length of the original message
 }
 
 impl<Id: ProtocolSessionId> From<Msg<Id>> for RbcMsg {
@@ -158,7 +157,6 @@ impl<Id: ProtocolSessionId> From<Msg<Id>> for RbcMsg {
             payload,
             metadata,
             msg_type: (&value.msg_type).into(),
-            msg_len: value.msg_len,
         }
     }
 }
@@ -485,7 +483,6 @@ pub extern "C" fn sync_bracha_process(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -520,7 +517,6 @@ pub extern "C" fn sync_bracha_broadcast(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -556,7 +552,6 @@ pub extern "C" fn sync_bracha_send(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -773,7 +768,6 @@ pub extern "C" fn sync_avid_process(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -808,7 +802,6 @@ pub extern "C" fn sync_avid_broadcast(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -844,7 +837,6 @@ pub extern "C" fn sync_avid_send(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -1064,7 +1056,6 @@ pub extern "C" fn sync_aba_process(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -1099,7 +1090,6 @@ pub extern "C" fn sync_aba_broadcast(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()
@@ -1135,7 +1125,6 @@ pub extern "C" fn sync_aba_send(
         payload: payload.to_vec(),
         metadata: metadata.to_vec(),
         msg_type: GenericMsgType::from(&msg.msg_type),
-        msg_len: msg.msg_len,
     };
     let result = match &*network {
         GenericNetwork::FakeNetwork(n) => tokio::runtime::Runtime::new()

--- a/mpc/src/honeybadger/batch_recon/batch_recon.rs
+++ b/mpc/src/honeybadger/batch_recon/batch_recon.rs
@@ -2,15 +2,9 @@ use super::*;
 use crate::{
     common::{
         share::{apply_vandermonde, make_vandermonde},
-        ProtocolSessionId, SecretSharingScheme,
+        SecretSharingScheme,
     },
-    honeybadger::{
-        fpmul::{PRandBitDMessage, PRandMessageType, RandBitMessage},
-        mul::MultMessage,
-        robust_interpolate::robust_interpolate::RobustShare,
-        triple_gen::TripleGenMessage,
-        ProtocolType, WrappedMessage,
-    },
+    honeybadger::{robust_interpolate::robust_interpolate::RobustShare, WrappedMessage},
 };
 use ark_ff::FftField;
 use ark_serialize::CanonicalSerialize;
@@ -18,7 +12,10 @@ use futures::lock::Mutex;
 use std::sync::Arc;
 use std::{collections::HashMap, marker::PhantomData};
 use stoffelnet::network_utils::Network;
+use tokio::sync::mpsc::Sender;
 use tracing::{debug, error, info, warn};
+
+pub static MAX_BATCH_RECON_SESSIONS: usize = 1024;
 /// --------------------------BatchRecPub--------------------------
 ///
 /// Goal: Publicly reconstruct t+1 secret-shared values [x₁, ..., x_{t+1}]
@@ -42,11 +39,18 @@ pub struct BatchReconNode<F: FftField> {
     pub t: usize,
     pub degree: usize,
     pub store: Arc<Mutex<HashMap<SessionId, Arc<Mutex<BatchReconStore<F>>>>>>, // Number of malicious parties
+    pub output_sender: Sender<SessionId>,
 }
 
 impl<F: FftField> BatchReconNode<F> {
     /// Creates a new `Node` instance.
-    pub fn new(id: usize, n: usize, t: usize, degree: usize) -> Result<Self, BatchReconError> {
+    pub fn new(
+        id: usize,
+        n: usize,
+        t: usize,
+        degree: usize,
+        output_sender: Sender<SessionId>,
+    ) -> Result<Self, BatchReconError> {
         let store = Arc::new(Mutex::new(HashMap::new()));
         Ok(Self {
             id,
@@ -54,6 +58,7 @@ impl<F: FftField> BatchReconNode<F> {
             t,
             degree,
             store,
+            output_sender,
         })
     }
 
@@ -62,9 +67,22 @@ impl<F: FftField> BatchReconNode<F> {
         store.clear();
     }
 
-    pub async fn clear_store(&self, session_id: SessionId) -> bool {
+    pub async fn get_store(&self, session_id: SessionId) -> Result<Vec<u8>, BatchReconError> {
         let mut store = self.store.lock().await;
-        store.remove(&session_id).is_some()
+
+        let output_store = store.remove(&session_id).ok_or_else(|| {
+            BatchReconError::InvalidInput("Session ID does not exist".to_string())
+        })?;
+
+        let store_lock = output_store.lock().await;
+
+        if store_lock.secrets.is_none() {
+            return Err(BatchReconError::InvalidInput(
+                "Batch reconstruction has not terminated".to_string(),
+            ));
+        }
+
+        Ok(store_lock.secrets.clone().unwrap())
     }
 
     /// Initiates the batch reconstruction protocol for a given node.
@@ -115,15 +133,6 @@ impl<F: FftField> BatchReconNode<F> {
         msg: BatchReconMsg,
         net: Arc<N>,
     ) -> Result<(), BatchReconError> {
-        let calling_proto = match msg.session_id.calling_protocol() {
-            Some(proto) => proto,
-            None => {
-                return Err(BatchReconError::InvalidInput(
-                    "Unknown calling protocol".to_string(),
-                ));
-            }
-        };
-
         match msg.msg_type {
             BatchReconMsgType::Eval => {
                 debug!(
@@ -136,7 +145,7 @@ impl<F: FftField> BatchReconNode<F> {
                     .map_err(|e| BatchReconError::ArkDeserialization(e))?;
 
                 // Lock the session store to update the session state.
-                let session_store = self.get_or_create_store(msg.session_id).await;
+                let session_store = self.get_or_create_store(msg.session_id).await?;
                 // Lock the session-specific store to access or update the session state.
                 let mut store = session_store.lock().await;
 
@@ -205,7 +214,7 @@ impl<F: FftField> BatchReconNode<F> {
                     .map_err(|e| BatchReconError::ArkDeserialization(e))?;
 
                 // Lock the session store to update the session state.
-                let session_store = self.get_or_create_store(msg.session_id).await;
+                let session_store = self.get_or_create_store(msg.session_id).await?;
                 // Lock the session-specific store to access or update the session state.
                 let mut store = session_store.lock().await;
 
@@ -229,79 +238,17 @@ impl<F: FftField> BatchReconNode<F> {
                             let mut result = poly;
                             // Resize the coefficient vector to `t + 1` to get all secrets.
                             result.resize(self.degree + 1, F::zero());
-                            store.secrets = Some(result.clone());
+                            let mut bytes_message = Vec::new();
+                            result.serialize_compressed(&mut bytes_message)?;
+
+                            store.secrets = Some(bytes_message);
                             drop(store);
                             info!(self_id = self.id, "Secrets successfully reconstructed");
 
-                            // Send the finalization message back to the triple generation or the
-                            // multiplication protocol.
-                            match calling_proto {
-                                ProtocolType::Triple => {
-                                    let mut bytes_message = Vec::new();
-                                    result.serialize_compressed(&mut bytes_message)?;
-                                    let triple_gen_generic_msg =
-                                        WrappedMessage::Triple(TripleGenMessage::new(
-                                            self.id,
-                                            msg.session_id,
-                                            bytes_message,
-                                        ));
-                                    let bytes_generic_msg =
-                                        bincode::serialize(&triple_gen_generic_msg)?;
-                                    net.send(self.id, &bytes_generic_msg).await?;
-                                }
-                                ProtocolType::Mul | ProtocolType::FpMul => {
-                                    let mut bytes_message = Vec::new();
-                                    result.serialize_compressed(&mut bytes_message)?;
-                                    let mult_generic_msg = WrappedMessage::Mul(MultMessage::new(
-                                        self.id,
-                                        msg.session_id,
-                                        bytes_message,
-                                    ));
-                                    let bytes_generic_msg = bincode::serialize(&mult_generic_msg)?;
-                                    net.send(self.id, &bytes_generic_msg).await?;
-                                }
-                                ProtocolType::RandBit => {
-                                    let mut bytes_message = Vec::new();
-                                    result.serialize_compressed(&mut bytes_message)?;
-                                    if msg.session_id.sub_id() == 0 {
-                                        let rand_generic_msg =
-                                            WrappedMessage::RandBit(RandBitMessage::new(
-                                                self.id,
-                                                msg.session_id,
-                                                bytes_message,
-                                            ));
-                                        let bytes_generic_msg =
-                                            bincode::serialize(&rand_generic_msg)?;
-                                        net.send(self.id, &bytes_generic_msg).await?;
-                                    } else {
-                                        let mult_generic_msg =
-                                            WrappedMessage::Mul(MultMessage::new(
-                                                self.id,
-                                                msg.session_id,
-                                                bytes_message,
-                                            ));
-                                        let bytes_generic_msg =
-                                            bincode::serialize(&mult_generic_msg)?;
-                                        net.send(self.id, &bytes_generic_msg).await?;
-                                    }
-                                }
-                                ProtocolType::PRandBit => {
-                                    let mut bytes_message = Vec::new();
-                                    result.serialize_compressed(&mut bytes_message)?;
-                                    let mult_generic_msg =
-                                        WrappedMessage::PRandBit(PRandBitDMessage::new(
-                                            self.id,
-                                            PRandMessageType::OutputMessage,
-                                            msg.session_id,
-                                            vec![],
-                                            vec![],
-                                            bytes_message,
-                                        ));
-                                    let bytes_generic_msg = bincode::serialize(&mult_generic_msg)?;
-                                    net.send(self.id, &bytes_generic_msg).await?;
-                                }
-                                _ => return Ok(()),
-                            }
+                            self.output_sender
+                                .send(msg.session_id)
+                                .await
+                                .map_err(|_| BatchReconError::SendError)?;
                         }
                         Err(e) => {
                             error!(
@@ -328,11 +275,16 @@ impl<F: FftField> BatchReconNode<F> {
     pub async fn get_or_create_store(
         &self,
         session_id: SessionId,
-    ) -> Arc<Mutex<BatchReconStore<F>>> {
+    ) -> Result<Arc<Mutex<BatchReconStore<F>>>, BatchReconError> {
         let mut storage = self.store.lock().await;
-        storage
+        if storage.len() >= MAX_BATCH_RECON_SESSIONS && !storage.contains_key(&session_id) {
+            return Err(BatchReconError::InvalidInput(
+                "Session limit reached".into(),
+            ));
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(BatchReconStore::empty())))
-            .clone()
+            .clone())
     }
 }

--- a/mpc/src/honeybadger/batch_recon/mod.rs
+++ b/mpc/src/honeybadger/batch_recon/mod.rs
@@ -49,7 +49,7 @@ pub struct BatchReconStore<F: FftField> {
     pub evals_received: Vec<RobustShare<F>>, // Stores (sender_id, eval_share) messages
     pub reveals_received: Vec<RobustShare<F>>, // Stores (sender_id, y_j_value) messages
     pub y_j: Option<RobustShare<F>>,         // The interpolated y_j value for this node's index
-    pub secrets: Option<Vec<F>>, // The finally reconstructed original secrets (polynomial coefficients)
+    pub secrets: Option<Vec<u8>>, // The finally reconstructed original secrets (polynomial coefficients)
 }
 
 impl<F: FftField> BatchReconStore<F> {
@@ -82,4 +82,6 @@ pub enum BatchReconError {
     InvalidInput(String),
     #[error("inner error: {0}")]
     InterpolateError(#[from] InterpolateError),
+    #[error("error sending the output of the batch reconstruction")]
+    SendError,
 }

--- a/mpc/src/honeybadger/fpmul/mod.rs
+++ b/mpc/src/honeybadger/fpmul/mod.rs
@@ -14,7 +14,7 @@ use ark_serialize::SerializationError;
 use bincode::ErrorKind;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use stoffelnet::network_utils::{NetworkError, PartyId};
+use stoffelnet::network_utils::NetworkError;
 use thiserror::Error;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 
@@ -64,6 +64,8 @@ pub enum RandBitError {
     ResultAlreadyReceived(SessionId),
     #[error("multiplication {0:?} did not complete in time")]
     Timeout(SessionId),
+    #[error("received abort signal")]
+    Abort,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -71,23 +73,6 @@ pub enum ProtocolState {
     Initialized,
     NotInitialized,
     Finished,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RandBitMessage {
-    pub sender: PartyId,
-    pub session_id: SessionId,
-    pub payload: Vec<u8>,
-}
-
-impl RandBitMessage {
-    pub fn new(sender: PartyId, session_id: SessionId, payload: Vec<u8>) -> Self {
-        Self {
-            sender,
-            session_id,
-            payload,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -167,18 +152,11 @@ pub enum PRandError {
     Timeout(SessionId),
 }
 
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
-pub enum PRandMessageType {
-    RissMessage,
-    OutputMessage,
-}
-
 /// Message sent in the Random Double Sharing protocol.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PRandBitDMessage {
     /// ID of the sender of the message.
     pub sender_id: usize,
-    pub msg_type: PRandMessageType,
     pub session_id: SessionId,
     pub tset: Vec<usize>,
     pub r_t: Vec<i64>,
@@ -189,7 +167,6 @@ impl PRandBitDMessage {
     /// Creates a new PRandBitDMessage.
     pub fn new(
         sender_id: usize,
-        msg_type: PRandMessageType,
         session_id: SessionId,
         tset: Vec<usize>,
         r_t: Vec<i64>,
@@ -197,7 +174,6 @@ impl PRandBitDMessage {
     ) -> Self {
         Self {
             sender_id,
-            msg_type,
             session_id,
             tset,
             r_t,

--- a/mpc/src/honeybadger/fpmul/prandbitd.rs
+++ b/mpc/src/honeybadger/fpmul/prandbitd.rs
@@ -5,7 +5,7 @@ use crate::{
         fpmul::{
             build_all_f_polys,
             f256::{build_all_f_polys_2_8, F2_8Domain, F2_8},
-            PRandBitDMessage, PRandBitDStore, PRandError, PRandMessageType, PrandState,
+            PRandBitDMessage, PRandBitDStore, PRandError, PrandState,
         },
         mul::concat_sorted,
         robust_interpolate::robust_interpolate::RobustShare,
@@ -19,7 +19,7 @@ use rand::Rng;
 use std::{collections::HashMap, sync::Arc, vec};
 use stoffelnet::network_utils::Network;
 use tokio::{
-    sync::Mutex,
+    sync::{mpsc::Receiver, Mutex},
     time::{timeout, Duration},
 };
 use tracing::info;
@@ -32,18 +32,21 @@ pub struct PRandBitNode<F: PrimeField, G: PrimeField> {
     pub t: usize,
     pub store: Arc<Mutex<HashMap<SessionId, Arc<Mutex<PRandBitDStore<F, G>>>>>>,
     pub batch_recon: BatchReconNode<F>,
+    pub batch_output: Arc<Mutex<Receiver<SessionId>>>,
 }
 
 impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
     /// Creates a new PRandBitDNode with empty shares.
     pub fn new(id: usize, n: usize, t: usize) -> Result<Self, PRandError> {
-        let batch_recon = BatchReconNode::new(id, n, t, t)?;
+        let (batch_sender, batch_receiver) = tokio::sync::mpsc::channel(200);
+        let batch_recon = BatchReconNode::new(id, n, t, t, batch_sender)?;
         Ok(Self {
             id,
             n,
             t,
             store: Arc::new(Mutex::new(HashMap::new())),
             batch_recon,
+            batch_output: Arc::new(Mutex::new(batch_receiver)),
         })
     }
 
@@ -51,6 +54,29 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
         let mut store = self.store.lock().await;
         self.batch_recon.clear_entire_store().await;
         store.clear();
+    }
+    pub async fn drain_batch_recon_output(&mut self) -> Result<(), PRandError> {
+        loop {
+            let id = {
+                let mut rx = self.batch_output.lock().await;
+                match rx.try_recv() {
+                    Ok(id) => id,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        return Err(PRandError::Abort);
+                    }
+                }
+            };
+
+            let output = self.batch_recon.get_store(id).await?;
+            match self.output_handler(id, output).await {
+                Ok(()) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
     }
     pub async fn wait_for_bit_result(
         &self,
@@ -467,7 +493,6 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
                 if !tset.contains(&j) {
                     let msg = WrappedMessage::PRandBit(PRandBitDMessage::new(
                         self.id,
-                        PRandMessageType::RissMessage,
                         session_id,
                         tset.clone(),
                         r_t_i.clone(),
@@ -481,7 +506,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
         Ok(())
     }
 
-    pub async fn riss_handler<N: Network + Send + Sync>(
+    pub async fn process<N: Network + Send + Sync>(
         &mut self,
         msg: PRandBitDMessage,
         network: Arc<N>,
@@ -535,20 +560,24 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
         Ok(())
     }
 
-    pub async fn output_handler(&mut self, msg: PRandBitDMessage) -> Result<(), PRandError> {
+    pub async fn output_handler(
+        &mut self,
+        sid: SessionId,
+        payload: Vec<u8>,
+    ) -> Result<(), PRandError> {
         info!(node_id = self.id, "At output handler");
 
-        let calling_proto = match msg.session_id.calling_protocol() {
+        let calling_proto = match sid.calling_protocol() {
             Some(proto) => proto,
             None => {
-                return Err(PRandError::SessionIdError(msg.session_id));
+                return Err(PRandError::SessionIdError(sid));
             }
         };
 
         let session_id = SessionId::new(
             calling_proto,
-            SessionId::pack_slot24(msg.session_id.exec_id(), 0, 0),
-            msg.session_id.instance_id(),
+            SessionId::pack_slot24(sid.exec_id(), 0, 0),
+            sid.instance_id(),
         );
 
         let binding = self.get_or_create_store(session_id).await;
@@ -559,29 +588,18 @@ impl<F: PrimeField, G: PrimeField> PRandBitNode<F, G> {
 
         // deserialize the field element from the payload
         let share_i_list: Vec<F> =
-            ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
-        let round_id = msg.session_id.round_id();
+            ark_serialize::CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
+        let round_id = sid.round_id();
         if store.output_open.contains_key(&round_id) {
             return Err(PRandError::Duplicate(format!(
-                "Already received from {}",
-                msg.sender_id
+                "Already received for {}",
+                round_id
             )));
         }
         store.output_open.insert(round_id, share_i_list);
         drop(store);
         self.try_finalize_bit(session_id, binding.clone()).await?;
         return Ok(());
-    }
-    pub async fn process<N: Network + Send + Sync>(
-        &mut self,
-        msg: PRandBitDMessage,
-        network: Arc<N>,
-    ) -> Result<(), PRandError> {
-        match msg.msg_type {
-            PRandMessageType::RissMessage => self.riss_handler(msg, network).await?,
-            PRandMessageType::OutputMessage => self.output_handler(msg).await?,
-        }
-        Ok(())
     }
 
     pub async fn get_or_create_store(

--- a/mpc/src/honeybadger/fpmul/rand_bit.rs
+++ b/mpc/src/honeybadger/fpmul/rand_bit.rs
@@ -1,6 +1,6 @@
 use crate::common::{ProtocolSessionId, RBC};
 use crate::honeybadger::batch_recon::batch_recon::BatchReconNode;
-use crate::honeybadger::fpmul::{ProtocolState, RandBitError, RandBitMessage, RandBitStorage};
+use crate::honeybadger::fpmul::{ProtocolState, RandBitError, RandBitStorage};
 use crate::honeybadger::mul::concat_sorted;
 use crate::honeybadger::mul::multiplication::Multiply;
 use crate::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::ops::{Add, Mul};
 use std::sync::Arc;
 use stoffelnet::network_utils::{Network, PartyId};
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 
@@ -50,6 +51,7 @@ where
     pub mult_node: Multiply<F, R>,
     /// Batch reconstruction node to reconstruct `a^2 mod p`.
     pub batch_recon: BatchReconNode<F>,
+    pub batch_output: Arc<Mutex<Receiver<SessionId>>>,
 }
 
 impl<F, R> RandBit<F, R>
@@ -58,7 +60,9 @@ where
     R: RBC<Id = SessionId>,
 {
     pub fn new(id: PartyId, n_parties: usize, threshold: usize) -> Result<Self, RandBitError> {
-        let batch_recon_node = BatchReconNode::new(id, n_parties, threshold, threshold)?;
+        let (batch_sender, batch_receiver) = tokio::sync::mpsc::channel(200);
+        let batch_recon_node =
+            BatchReconNode::new(id, n_parties, threshold, threshold, batch_sender)?;
         let mult_node = Multiply::new(id, n_parties, threshold)?;
         Ok(Self {
             id,
@@ -67,6 +71,7 @@ where
             storage: Arc::new(Mutex::new(HashMap::new())),
             mult_node,
             batch_recon: batch_recon_node,
+            batch_output: Arc::new(Mutex::new(batch_receiver)),
         })
     }
 
@@ -94,7 +99,29 @@ where
             .or_insert(Arc::new(Mutex::new(RandBitStorage::empty())))
             .clone())
     }
+    pub async fn drain_batch_recon_output(&mut self) -> Result<(), RandBitError> {
+        loop {
+            let id = {
+                let mut rx = self.batch_output.lock().await;
+                match rx.try_recv() {
+                    Ok(id) => id,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        return Err(RandBitError::Abort);
+                    }
+                }
+            };
 
+            let output = self.batch_recon.get_store(id).await?;
+            match self.square_reconstruction_handler(id, output).await {
+                Ok(()) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
     pub async fn wait_for_result(
         &self,
         session_id: SessionId,
@@ -248,24 +275,25 @@ where
 
     async fn square_reconstruction_handler(
         &self,
-        message: RandBitMessage,
+        sid: SessionId,
+        payload: Vec<u8>,
     ) -> Result<(), RandBitError> {
         tracing::info!(
-            "Rand_bit reconstruction msg received from node: {0:?}",
-            message.sender
+            "Rand_bit reconstruction msg received at node: {0:?}",
+            self.id
         );
 
-        let calling_proto = match message.session_id.calling_protocol() {
+        let calling_proto = match sid.calling_protocol() {
             Some(proto) => proto,
             None => {
-                return Err(RandBitError::NoSuchSessionId(message.session_id));
+                return Err(RandBitError::NoSuchSessionId(sid));
             }
         };
 
         let session_id = SessionId::new(
             calling_proto,
-            SessionId::pack_slot24(message.session_id.exec_id(), 0, 0),
-            message.session_id.instance_id(),
+            SessionId::pack_slot24(sid.exec_id(), 0, 0),
+            sid.instance_id(),
         );
         let storage_bind = self.get_or_create_storage(session_id).await?;
         let mut storage = storage_bind.lock().await;
@@ -273,13 +301,12 @@ where
             return Ok(());
         }
 
-        let open: Vec<F> =
-            CanonicalDeserialize::deserialize_compressed(message.payload.as_slice())?;
-        let round_id = message.session_id.round_id();
+        let open: Vec<F> = CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
+        let round_id = sid.round_id();
         if storage.output_open.contains_key(&round_id) {
             return Err(RandBitError::Duplicate(format!(
-                "Already received from {}",
-                message.sender
+                "Already received for {}",
+                round_id
             )));
         }
         storage.output_open.insert(round_id, open);
@@ -291,11 +318,6 @@ where
         drop(storage);
         let _done = self.try_finalize(session_id).await?;
         return Ok(());
-    }
-
-    pub async fn process(&mut self, message: RandBitMessage) -> Result<(), RandBitError> {
-        self.square_reconstruction_handler(message).await?;
-        Ok(())
     }
 }
 

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -170,6 +170,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
         let mut send_over_network = false;
         let mut already_rand_shares = false;
         let mut unknown_client = false;
+        let mut invalid_length = false;
 
         self.status_sender.send_if_modified(|status| {
             match status.get(&client_id) {
@@ -178,6 +179,10 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
                     false
                 }
                 Some((InputType::MaskedInputs, masked_inputs)) => {
+                    if masked_inputs.len() != shares.len() {
+                        invalid_length = true;
+                        return false;
+                    }
                     let input_shares = calculate_input_shares(masked_inputs, &shares);
 
                     status.insert(client_id, (InputType::InputShares, input_shares));
@@ -200,6 +205,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
             }
         });
 
+        if invalid_length {
+            return Err(InputError::InvalidInput(
+                "Mismatch in masked input and share length".to_string(),
+            ));
+        }
         if unknown_client {
             return Err(InputError::InvalidInput(
                 "Unknown client {client_id}".to_string(),
@@ -249,6 +259,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
 
         let mut unknown_client = false;
         let mut already_masked_inputs = false;
+        let mut invalid_length = false;
 
         self.status_sender
             .send_if_modified(|status| match status.get(&sender_id) {
@@ -257,6 +268,10 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
                     false
                 }
                 Some((InputType::RandomShares, random_shares)) => {
+                    if masked_inputs_as_shares.len() != random_shares.len() {
+                        invalid_length = true;
+                        return false;
+                    }
                     let input_shares =
                         calculate_input_shares(&masked_inputs_as_shares, random_shares);
 
@@ -285,7 +300,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
                     false
                 }
             });
-
+        if invalid_length {
+            return Err(InputError::InvalidInput(
+                "Mismatch in masked input and share length".to_string(),
+            ));
+        }
         if already_masked_inputs {
             return Err(InputError::Duplicate(format!(
                 "Server {} already received masked inputs from {}",
@@ -392,9 +411,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputClient<F, R> {
         msg: InputMessage,
         net: Arc<N>,
     ) -> Result<(), InputError> {
-        let shares: Vec<RobustShare<F>> =
+        let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
-
+        for share in &mut shares {
+            share.id = msg.sender_id;
+        }
         let mut d = self.client_data.lock().await;
 
         let input_len = d.inputs.len();

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -46,13 +46,13 @@ use crate::{
             fpmul::{FPError, FPMulNode},
             prandbitd::PRandBitNode,
             rand_bit::RandBit,
-            PRandBitDMessage, PRandError, RandBitError, RandBitMessage, TruncPrError,
+            PRandBitDMessage, PRandError, RandBitError, TruncPrError,
         },
         input::{
             input::{InputClient, InputServer},
             InputError, InputMessage,
         },
-        mul::{multiplication::Multiply, MulError, MultMessage},
+        mul::{multiplication::Multiply, MulError},
         output::{
             output::{OutputClient, OutputServer},
             OutputError, OutputMessage,
@@ -61,7 +61,7 @@ use crate::{
         ran_dou_sha::messages::RanDouShaMessage,
         robust_interpolate::robust_interpolate::Robust,
         share_gen::{share_gen::RanShaNode, RanShaError, RanShaMessage},
-        triple_gen::{TripleGenError, TripleGenMessage},
+        triple_gen::TripleGenError,
     },
 };
 use ark_ff::{FftField, PrimeField};
@@ -610,43 +610,6 @@ where
                 }
                 self.preprocess.ran_dou_sha.process(rds_msg, net).await?;
             }
-            WrappedMessage::Mul(mul_msg) => {
-                if sender_id != mul_msg.sender {
-                    return Err(HoneyBadgerError::InvalidPartyId);
-                }
-                if mul_msg.session_id.instance_id() != self.params.instance_id {
-                    return Err(HoneyBadgerError::InstanceIdError(
-                        mul_msg.session_id.instance_id(),
-                    ));
-                }
-
-                match mul_msg.session_id.calling_protocol() {
-                    Some(ProtocolType::Mul) => self.operations.mul.process(mul_msg).await?,
-                    Some(ProtocolType::RandBit) => {
-                        self.preprocess.rand_bit.mult_node.process(mul_msg).await?
-                    }
-                    Some(ProtocolType::FpMul) => {
-                        self.type_ops.fpmul.mult_node.process(mul_msg).await?
-                    }
-                    _ => {
-                        warn!(
-                            "Unknown protocol ID in session ID: {:?} in MUL",
-                            mul_msg.session_id
-                        );
-                    }
-                }
-            }
-            WrappedMessage::Triple(triple_msg) => {
-                if sender_id != triple_msg.sender_id {
-                    return Err(HoneyBadgerError::InvalidPartyId);
-                }
-                if triple_msg.session_id.instance_id() != self.params.instance_id {
-                    return Err(HoneyBadgerError::InstanceIdError(
-                        triple_msg.session_id.instance_id(),
-                    ));
-                }
-                self.preprocess.triple_gen.process(triple_msg).await?;
-            }
             WrappedMessage::BatchRecon(batch_msg) => {
                 if sender_id != batch_msg.sender_id {
                     return Err(HoneyBadgerError::InvalidPartyId);
@@ -662,13 +625,18 @@ where
                             .mul
                             .batch_recon
                             .process(batch_msg, net)
-                            .await?
+                            .await?;
+                        self.operations.mul.drain_batch_recon_output().await?
                     }
                     Some(ProtocolType::Triple) => {
                         self.preprocess
                             .triple_gen
                             .batch_recon_node
                             .process(batch_msg, net)
+                            .await?;
+                        self.preprocess
+                            .triple_gen
+                            .drain_batch_recon_output()
                             .await?
                     }
                     Some(ProtocolType::RandBit) => {
@@ -677,14 +645,20 @@ where
                                 .rand_bit
                                 .batch_recon
                                 .process(batch_msg, net)
-                                .await?
+                                .await?;
+                            self.preprocess.rand_bit.drain_batch_recon_output().await?;
                         } else {
                             self.preprocess
                                 .rand_bit
                                 .mult_node
                                 .batch_recon
                                 .process(batch_msg, net)
-                                .await?
+                                .await?;
+                            self.preprocess
+                                .rand_bit
+                                .mult_node
+                                .drain_batch_recon_output()
+                                .await?;
                         }
                     }
                     Some(ProtocolType::PRandBit) => {
@@ -692,7 +666,9 @@ where
                             .prand_bit
                             .batch_recon
                             .process(batch_msg, net)
-                            .await?
+                            .await?;
+
+                        self.preprocess.prand_bit.drain_batch_recon_output().await?;
                     }
                     Some(ProtocolType::FpMul) => {
                         self.type_ops
@@ -700,7 +676,12 @@ where
                             .mult_node
                             .batch_recon
                             .process(batch_msg, net)
-                            .await?
+                            .await?;
+                        self.type_ops
+                            .fpmul
+                            .mult_node
+                            .drain_batch_recon_output()
+                            .await?;
                     }
                     _ => {
                         warn!(
@@ -709,17 +690,6 @@ where
                         );
                     }
                 }
-            }
-            WrappedMessage::RandBit(rand_bit_message) => {
-                if sender_id != rand_bit_message.sender {
-                    return Err(HoneyBadgerError::InvalidPartyId);
-                }
-                if rand_bit_message.session_id.instance_id() != self.params.instance_id {
-                    return Err(HoneyBadgerError::InstanceIdError(
-                        rand_bit_message.session_id.instance_id(),
-                    ));
-                }
-                self.preprocess.rand_bit.process(rand_bit_message).await?;
             }
             WrappedMessage::PRandBit(prand_message) => {
                 if sender_id != prand_message.sender_id {
@@ -1133,13 +1103,6 @@ where
                     .lock()
                     .await
                     .add(Some(triples), None, None, None);
-                assert!(
-                    self.preprocess
-                        .triple_gen
-                        .batch_recon_node
-                        .clear_store(sessionid)
-                        .await
-                );
                 assert!(self.preprocess.triple_gen.clear_store(sessionid).await);
 
                 if round_id == 255 {
@@ -1490,11 +1453,8 @@ pub enum WrappedMessage {
     BatchRecon(BatchReconMsg),
     Input(InputMessage),
     RanSha(RanShaMessage),
-    Triple(TripleGenMessage),
     Dousha(DouShaMessage),
-    Mul(MultMessage),
     Output(OutputMessage),
-    RandBit(RandBitMessage),
     PRandBit(PRandBitDMessage),
 }
 

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -135,6 +135,7 @@ pub struct Multiply<F: FftField, R: RBC> {
     pub t: usize,
     pub mult_storage: Arc<Mutex<HashMap<SessionId, Arc<Mutex<MultStorage<F>>>>>>,
     pub batch_recon: BatchReconNode<F>,
+    pub batch_output: Arc<Mutex<Receiver<SessionId>>>,
     pub rbc: R,
     pub rbc_output: Arc<Mutex<Receiver<SessionId>>>,
 }
@@ -142,7 +143,8 @@ pub struct Multiply<F: FftField, R: RBC> {
 impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
     pub fn new(id: PartyId, n: usize, threshold: usize) -> Result<Self, MulError> {
         let (rbc_sender, rbc_receiver) = mpsc::channel(200);
-        let batch_recon = BatchReconNode::<F>::new(id, n, threshold, threshold)?;
+        let (batch_sender, batch_receiver) = tokio::sync::mpsc::channel(200);
+        let batch_recon = BatchReconNode::<F>::new(id, n, threshold, threshold, batch_sender)?;
         let rbc = R::new(
             id,
             n,
@@ -157,6 +159,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             t: threshold,
             mult_storage: Arc::new(Mutex::new(HashMap::new())),
             batch_recon,
+            batch_output: Arc::new(Mutex::new(batch_receiver)),
             rbc,
             rbc_output: Arc::new(Mutex::new(rbc_receiver)),
         })
@@ -177,7 +180,32 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
 
-            match self.open_mult_handler(msg).await {
+            match self
+                .open_mult_handler(msg.sender, msg.session_id, msg.payload)
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+    pub async fn drain_batch_recon_output(&mut self) -> Result<(), MulError> {
+        loop {
+            let id = {
+                let mut rx = self.batch_output.lock().await;
+                match rx.try_recv() {
+                    Ok(id) => id,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        return Err(MulError::Abort);
+                    }
+                }
+            };
+            let output = self.batch_recon.get_store(id).await?;
+            match self.open_mult_handler(self.id, id, output).await {
                 Ok(()) => {}
                 Err(e) => {
                     return Err(e);
@@ -385,21 +413,26 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
     // `open_mult_handler` mainly serves to receive opened values from batch reconstruction
     // or shares from RBC, from which openings will be manually reconstructed.
     // If `init` has been called, then it can also try to perform the multiplication.
-    pub async fn open_mult_handler(&self, msg: MultMessage) -> Result<(), MulError> {
-        let calling_proto = match msg.session_id.calling_protocol() {
+    pub async fn open_mult_handler(
+        &self,
+        sender: usize,
+        sid: SessionId,
+        payload: Vec<u8>,
+    ) -> Result<(), MulError> {
+        let calling_proto = match sid.calling_protocol() {
             Some(proto) => proto,
             None => {
                 return Err(MulError::InvalidInput(format!(
                     "Unknown calling protocol in session ID {:?}",
-                    msg.session_id
+                    sid
                 )));
             }
         };
 
         let session_id = SessionId::new(
             calling_proto,
-            SessionId::pack_slot24(msg.session_id.exec_id(), 0, 0),
-            msg.session_id.instance_id(),
+            SessionId::pack_slot24(sid.exec_id(), 0, 0),
+            sid.instance_id(),
         );
 
         // 1.
@@ -411,10 +444,9 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
         }
 
         // 2.
-        if msg.session_id.sub_id() == 1 {
-            let open: Vec<F> =
-                CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
-            let round_id = msg.session_id.round_id();
+        if sid.sub_id() == 1 {
+            let open: Vec<F> = CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
+            let round_id = sid.round_id();
             let (target_map, label) = if round_id % 2 == 0 {
                 (&mut storage.output_open_mult1, "a-x")
             } else {
@@ -437,24 +469,24 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             );
 
             target_map.insert(round_id, open);
-        } else if msg.session_id.sub_id() == 2 {
+        } else if sid.sub_id() == 2 {
             info!(
                 self_id = self.id,
                 "Received shares for reconstruction using RBC for session_id: {:?}", session_id
             );
-            if storage.received_shares.contains_key(&msg.sender) {
+            if storage.received_shares.contains_key(&sender) {
                 return Err(MulError::Duplicate(format!(
                     "Already received shares for reconstruction using RBC from {}",
-                    msg.sender
+                    sender
                 )));
             }
 
             let open_message: ReconstructionMessage<F> =
-                CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
+                CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
 
             storage
                 .received_shares
-                .insert(msg.sender, (open_message.a_sub_x, open_message.b_sub_y));
+                .insert(sender, (open_message.a_sub_x, open_message.b_sub_y));
         }
 
         // 3.
@@ -496,11 +528,6 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
 
         info!("Multiplication completed at node {}", self.id);
 
-        Ok(())
-    }
-
-    pub async fn process(&mut self, message: MultMessage) -> Result<(), MulError> {
-        self.open_mult_handler(message).await?;
         Ok(())
     }
 
@@ -769,6 +796,7 @@ pub mod tests {
                                 .process(batchrecon_msg, network[i].clone())
                                 .await
                                 .unwrap();
+                            let _ = node.drain_batch_recon_output().await;
                         }
                         WrappedMessage::Rbc(rbc_msg) => {
                             match node.rbc.process(rbc_msg, network[i].clone()).await {
@@ -778,9 +806,6 @@ pub mod tests {
                                 }
                             }
                             let _ = node.drain_rbc_output().await;
-                        }
-                        WrappedMessage::Mul(input_msg) => {
-                            let _ = node.process(input_msg).await;
                         }
                         _ => {
                             panic!();
@@ -961,7 +986,7 @@ pub mod tests {
         }
 
         // 4. Create node
-        let mut mul_node = Multiply::<Fr, Avid<SessionId>>::new(node_id, n_parties, t).unwrap();
+        let mul_node = Multiply::<Fr, Avid<SessionId>>::new(node_id, n_parties, t).unwrap();
 
         let storage_bind = mul_node.get_or_create_mult_storage(session_id).await;
         let mut storage = storage_bind.lock().await;
@@ -1057,7 +1082,9 @@ pub mod tests {
 
         // 7. Make node handle messages
         for msg in mul_msgs {
-            let result = mul_node.process(msg).await;
+            let result = mul_node
+                .open_mult_handler(msg.sender, msg.session_id, msg.payload)
+                .await;
             match result {
                 Ok(()) => {}
                 Err(MulError::Duplicate(e)) => {

--- a/mpc/src/honeybadger/output/output.rs
+++ b/mpc/src/honeybadger/output/output.rs
@@ -105,9 +105,12 @@ impl<F: FftField> OutputClient<F> {
     ///    attempt to reconstruct the output using robust interpolation.
     pub async fn output_handler(&mut self, msg: OutputMessage) -> Result<(), OutputError> {
         // 1.
-        let shares: Vec<RobustShare<F>> =
+        let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
 
+        for share in &mut shares {
+            share.id = msg.sender_id;
+        }
         if shares.len() != self.input_len {
             return Err(OutputError::InvalidInput(
                 "Mismatch in input and share length".to_string(),

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -409,6 +409,11 @@ where
         if rec_msg.r_share_deg_t.id != sender_id || rec_msg.r_share_deg_2t.id != sender_id {
             return Err(RanDouShaError::IncorrectID);
         }
+        if rec_msg.r_share_deg_t.degree != self.threshold
+            || rec_msg.r_share_deg_2t.degree != 2 * self.threshold
+        {
+            return Err(RanDouShaError::ShareError(ShareError::DegreeMismatch));
+        }
         let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
 
@@ -442,23 +447,27 @@ where
                 drop(store);
                 // (5) Perform reconstruction for both degrees.
                 // ShamirSecretSharing::reconstruct expects a vector of shares.
-                let reconstructed_r_t = NonRobustShare::recover_secret(
-                    &shares_t_for_recon,
-                    self.n_parties,
-                    self.threshold,
-                )?;
-                let reconstructed_r_2t = NonRobustShare::recover_secret(
-                    &shares_2t_for_recon,
-                    self.n_parties,
-                    self.threshold,
-                )?;
-                let poly1 = DensePolynomial::from_coefficients_slice(&reconstructed_r_t.0);
-                let poly2 = DensePolynomial::from_coefficients_slice(&reconstructed_r_2t.0);
-
-                let ok = (self.threshold == poly1.degree())
-                    && (2 * self.threshold == poly2.degree())
-                    && (reconstructed_r_t.1 == reconstructed_r_2t.1);
-
+                let ok = match (
+                    NonRobustShare::recover_secret(
+                        &shares_t_for_recon,
+                        self.n_parties,
+                        self.threshold,
+                    ),
+                    NonRobustShare::recover_secret(
+                        &shares_2t_for_recon,
+                        self.n_parties,
+                        self.threshold,
+                    ),
+                ) {
+                    (Ok(reconstructed_r_t), Ok(reconstructed_r_2t)) => {
+                        let poly1 = DensePolynomial::from_coefficients_slice(&reconstructed_r_t.0);
+                        let poly2 = DensePolynomial::from_coefficients_slice(&reconstructed_r_2t.0);
+                        (self.threshold == poly1.degree())
+                            && (2 * self.threshold == poly2.degree())
+                            && (reconstructed_r_t.1 == reconstructed_r_2t.1)
+                    }
+                    _ => false,
+                };
                 let msg =
                     RanDouShaMessage::new(self.id, msg.session_id, RanDouShaPayload::Output(ok));
 
@@ -554,7 +563,11 @@ mod tests {
                 SessionId::pack_slot24(exec, 0, round),
                 111,
             );
-            let rec_msg = ReconstructionMessage::<Fr>::new(Default::default(), Default::default());
+
+            let share_deg_t = NonRobustShare::new(Fr::from(0), 0, 1);
+            let share_deg_2t = NonRobustShare::new(Fr::from(0), 0, 2);
+            let rec_msg = ReconstructionMessage::new(share_deg_t, share_deg_2t);
+
             let mut payload = Vec::new();
             rec_msg.serialize_compressed(&mut payload).unwrap();
             let msg = RanDouShaMessage::new(0, sid, RanDouShaPayload::Reconstruct(payload));
@@ -576,7 +589,9 @@ mod tests {
             SessionId::pack_slot24(255, 0, 255),
             0,
         );
-        let rec_msg = ReconstructionMessage::<Fr>::new(Default::default(), Default::default());
+        let share_deg_t = NonRobustShare::new(Fr::from(0), 0, 1);
+        let share_deg_2t = NonRobustShare::new(Fr::from(0), 0, 2);
+        let rec_msg = ReconstructionMessage::new(share_deg_t, share_deg_2t);
         let mut payload = Vec::new();
         rec_msg.serialize_compressed(&mut payload).unwrap();
         let msg = RanDouShaMessage::new(0, over_sid, RanDouShaPayload::Reconstruct(payload));

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -335,6 +335,9 @@ where
         if share.degree != self.threshold {
             return Err(RanShaError::ShareError(ShareError::DegreeMismatch));
         }
+        if share.id != msg.sender_id {
+            return Err(RanShaError::ShareError(ShareError::IdMismatch));
+        }
         let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
         if store.state == RanShaState::Finished {

--- a/mpc/src/honeybadger/triple_gen/mod.rs
+++ b/mpc/src/honeybadger/triple_gen/mod.rs
@@ -1,8 +1,7 @@
 use ark_ff::FftField;
 use ark_serialize::SerializationError;
 use bincode::ErrorKind;
-use serde::{Deserialize, Serialize};
-use stoffelnet::network_utils::{NetworkError, PartyId};
+use stoffelnet::network_utils::NetworkError;
 use thiserror::Error;
 use tokio::{
     sync::oneshot::{channel, Receiver, Sender},
@@ -66,6 +65,8 @@ pub enum TripleGenError {
     ResultAlreadyReceived(SessionId),
     #[error("multiplication {0:?} did not complete in time")]
     Timeout(SessionId),
+    #[error("received abort signal")]
+    Abort,
 }
 
 /// Represents a Beaver triple of non-robust Shamir shares.
@@ -124,33 +125,6 @@ where
             protocol_output: Vec::new(),
             output_sender: Some(output_sender),
             output_receiver: Some(output_receiver),
-        }
-    }
-}
-
-/// Generic message for the triple generation protocol.
-///
-/// This generic message contains the payload in bytes of any message sent during the protocol
-/// execution. Any message that is sent in the protocol is converted into bytes that are placed in
-/// the `payload`. Once a party receives a message, it takes the payload and deserialize it to the
-/// specific message sent during the protocol execution.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TripleGenMessage {
-    /// The ID of the party.
-    pub sender_id: PartyId,
-    /// The session ID of the instance.
-    pub session_id: SessionId,
-    /// The payload of the message.
-    pub payload: Vec<u8>,
-}
-
-impl TripleGenMessage {
-    /// Creates a new generic message for the triple generation protocol.
-    pub fn new(sender_id: PartyId, session_id: SessionId, payload: Vec<u8>) -> Self {
-        Self {
-            sender_id,
-            session_id,
-            payload,
         }
     }
 }

--- a/mpc/src/honeybadger/triple_gen/triple_generation.rs
+++ b/mpc/src/honeybadger/triple_gen/triple_generation.rs
@@ -4,11 +4,12 @@ use ark_ff::FftField;
 use ark_serialize::CanonicalDeserialize;
 use itertools::izip;
 use stoffelnet::network_utils::{Network, PartyId};
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 use tracing::info;
 
-use crate::honeybadger::triple_gen::{TripleGenError, TripleGenMessage, TripleGenStorage};
+use crate::honeybadger::triple_gen::{TripleGenError, TripleGenStorage};
 use crate::honeybadger::{
     double_share::DoubleShamirShare, triple_gen::ShamirBeaverTriple, SessionId,
 };
@@ -44,6 +45,7 @@ where
     pub storage: Arc<Mutex<HashMap<SessionId, Arc<Mutex<TripleGenStorage<F>>>>>>,
     /// Batch reconstruction node used in the triple generation
     pub batch_recon_node: BatchReconNode<F>,
+    pub batch_output: Arc<Mutex<Receiver<SessionId>>>,
 }
 
 pub static MAX_TRIPLE_GEN_SESSIONS: usize = 1024;
@@ -53,14 +55,17 @@ where
     F: FftField,
 {
     pub fn new(id: PartyId, n_parties: usize, threshold: usize) -> Result<Self, TripleGenError> {
+        let (batch_sender, batch_receiver) = tokio::sync::mpsc::channel(200);
         // batch_recon_node is for opening degree 2t shares
-        let batch_recon_node = BatchReconNode::<F>::new(id, n_parties, threshold, threshold * 2)?;
+        let batch_recon_node =
+            BatchReconNode::<F>::new(id, n_parties, threshold, threshold * 2, batch_sender)?;
         Ok(Self {
             id,
             n_parties,
             threshold,
             storage: Arc::new(Mutex::new(HashMap::new())),
             batch_recon_node,
+            batch_output: Arc::new(Mutex::new(batch_receiver)),
         })
     }
 
@@ -86,6 +91,29 @@ where
         store.remove(&session_id).is_some()
     }
 
+    pub async fn drain_batch_recon_output(&mut self) -> Result<(), TripleGenError> {
+        loop {
+            let id = {
+                let mut rx = self.batch_output.lock().await;
+                match rx.try_recv() {
+                    Ok(id) => id,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                        return Err(TripleGenError::Abort);
+                    }
+                }
+            };
+
+            let output = self.batch_recon_node.get_store(id).await?;
+            match self.batch_recon_finish_handler(id, output).await {
+                Ok(()) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
     pub async fn wait_for_result(
         &self,
         session_id: SessionId,
@@ -251,19 +279,20 @@ where
 
     pub async fn batch_recon_finish_handler(
         &mut self,
-        message: TripleGenMessage,
+        session_id: SessionId,
+        payload: Vec<u8>,
     ) -> Result<(), TripleGenError> {
         info!("Handling Batch reconstruction results");
         let batch_recon_result: Vec<F> =
-            CanonicalDeserialize::deserialize_compressed(message.payload.as_slice())?;
+            CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
 
         // SHOULD NEVER HAPPEN, since comes from batch reconstruction
-        if message.session_id.sub_id() != 0 {
-            return Err(TripleGenError::SessionIdError(message.session_id));
+        if session_id.sub_id() != 0 {
+            return Err(TripleGenError::SessionIdError(session_id));
         }
 
         // SHOULD ALSO NEVER FAIL, since comes from batch reconstruction
-        let storage_bind = self.get_or_create_store(message.session_id).await?;
+        let storage_bind = self.get_or_create_store(session_id).await?;
         {
             let mut storage = storage_bind.lock().await;
 
@@ -275,14 +304,9 @@ where
             storage.batch_recon_result = Some(batch_recon_result);
         }
 
-        self.try_finalize_triple_gen(message.session_id, storage_bind)
+        self.try_finalize_triple_gen(session_id, storage_bind)
             .await?;
 
-        Ok(())
-    }
-
-    pub async fn process(&mut self, message: TripleGenMessage) -> Result<(), TripleGenError> {
-        self.batch_recon_finish_handler(message).await?;
         Ok(())
     }
 }

--- a/mpc/tests/batchrecon_test.rs
+++ b/mpc/tests/batchrecon_test.rs
@@ -142,7 +142,8 @@ mod tests {
 
         let mut handles = vec![];
         for i in 0..n {
-            let mut node = BatchReconNode::new(i, n, t, t).unwrap();
+            let (batch_sender, _batch_receiver) = tokio::sync::mpsc::channel(200);
+            let mut node = BatchReconNode::new(i, n, t, t, batch_sender).unwrap();
             let shares = all_shares[i].clone();
             let net_clone = net[i].clone();
             let inboxes = receivers[i].drain(..).collect::<Vec<_>>();
@@ -163,7 +164,7 @@ mod tests {
                     Err(e) => warn!(id =i,error = ?e,"Sending failure"),
                 }
                 // Lock the session store to update the session state.
-                let session_store = node.get_or_create_store(session_id).await;
+                let session_store = node.get_or_create_store(session_id).await.unwrap();
 
                 while {
                     let s = session_store.lock().await;
@@ -198,7 +199,10 @@ mod tests {
         }
         for handle in handles {
             let recovered = handle.await.unwrap();
-            assert_eq!(recovered[..secrets.len()], secrets[..]);
+            let batch_recon_result: Vec<Fr> =
+                CanonicalDeserialize::deserialize_compressed(recovered.as_slice()).unwrap();
+
+            assert_eq!(batch_recon_result[..secrets.len()], secrets[..]);
         }
     }
 }

--- a/mpc/tests/fpmul_test.rs
+++ b/mpc/tests/fpmul_test.rs
@@ -88,6 +88,7 @@ async fn test_prandbitd_end_to_end() {
                     }
                     WrappedMessage::BatchRecon(msg) => {
                         let _ = node.batch_recon.process(msg, net.clone()).await;
+                        let _ = node.drain_batch_recon_output().await;
                     }
                     _ => continue,
                 }

--- a/mpc/tests/mul_test.rs
+++ b/mpc/tests/mul_test.rs
@@ -10,8 +10,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration, vec};
 use stoffelmpc_mpc::common::ProtocolSessionId;
 use stoffelmpc_mpc::common::{rbc::rbc::Avid, SecretSharingScheme, RBC};
 use stoffelmpc_mpc::honeybadger::{
-    mul::{multiplication::Multiply, MulError},
-    robust_interpolate::robust_interpolate::RobustShare,
+    mul::multiplication::Multiply, robust_interpolate::robust_interpolate::RobustShare,
     ProtocolType, SessionId, WrappedMessage,
 };
 use stoffelmpc_network::fake_network::SenderId;
@@ -146,19 +145,6 @@ async fn mul_e2e(n_parties: usize, t: usize, no_of_mul: usize) {
                 };
                 // Match the message type and route it appropriately
                 match &wrapped {
-                    WrappedMessage::Mul(msg) => {
-                        let result = mul_node.process(msg.clone()).await;
-
-                        match result {
-                            Ok(()) => {}
-                            Err(MulError::ResultAlreadyReceived(_)) => {
-                                info!("{} already received result", mul_node.id);
-                            }
-                            Err(e) => {
-                                panic!("Node {} encountered unexpected error: {e}", mul_node.id);
-                            }
-                        }
-                    }
                     WrappedMessage::Rbc(msg) => {
                         if let Err(e) = mul_node
                             .rbc
@@ -173,11 +159,14 @@ async fn mul_e2e(n_parties: usize, t: usize, no_of_mul: usize) {
                     }
                     WrappedMessage::BatchRecon(batch_msg) => {
                         match batch_msg.session_id.calling_protocol() {
-                            Some(ProtocolType::Mul) => mul_node
-                                .batch_recon
-                                .process(batch_msg.clone(), Arc::clone(&net_clone))
-                                .await
-                                .expect("batch recon error"),
+                            Some(ProtocolType::Mul) => {
+                                mul_node
+                                    .batch_recon
+                                    .process(batch_msg.clone(), Arc::clone(&net_clone))
+                                    .await
+                                    .expect("batch recon error");
+                                mul_node.drain_batch_recon_output().await.unwrap();
+                            }
                             _ => {
                                 panic!("Unexpected caller of batch recon");
                             }

--- a/mpc/tests/rbc_test.rs
+++ b/mpc/tests/rbc_test.rs
@@ -201,7 +201,6 @@ mod tests {
             payload.clone(),
             vec![],
             GenericMsgType::Bracha(MsgType::Ready),
-            payload.clone().len(),
         );
         let echo_msg = Msg::new(
             sender_id,
@@ -210,7 +209,6 @@ mod tests {
             payload.clone(),
             vec![],
             GenericMsgType::Bracha(MsgType::Echo),
-            payload.len(),
         );
 
         // Send READY first
@@ -407,7 +405,6 @@ mod tests {
             payload.clone(),
             vec![],
             GenericMsgType::Avid(MsgTypeAvid::Ready),
-            payload.clone().len(),
         );
         let echo_msg = Msg::new(
             sender_id,
@@ -416,7 +413,6 @@ mod tests {
             payload.clone(),
             vec![],
             GenericMsgType::Avid(MsgTypeAvid::Echo),
-            payload.len(),
         );
 
         // Send READY first
@@ -610,7 +606,6 @@ mod tests {
             vec![],
             vec![],
             GenericMsgType::ABA(MsgTypeAba::Key),
-            0,
         );
         let _ = dealer
             .distribute_keys(
@@ -632,7 +627,6 @@ mod tests {
                 vec![],
                 vec![],
                 GenericMsgType::ABA(MsgTypeAba::Coin),
-                0,
             );
             let _ = aba.init_coin(coin_msg, net[aba.id].clone()).await;
         }
@@ -696,7 +690,6 @@ mod tests {
             vec![],
             vec![],
             GenericMsgType::ABA(MsgTypeAba::Key),
-            0,
         );
         let _ = dealer
             .distribute_keys(
@@ -811,7 +804,6 @@ mod tests {
             vec![],
             vec![],
             GenericMsgType::ABA(MsgTypeAba::Key),
-            0,
         );
         let _ = dealer
             .distribute_keys(

--- a/mpc/tests/utils/triple_gen_utils.rs
+++ b/mpc/tests/utils/triple_gen_utils.rs
@@ -12,7 +12,7 @@ use stoffelmpc_mpc::{
 use stoffelmpc_network::fake_network::{FakeNetwork, SenderId};
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::Mutex;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::utils::test_utils::fan_in_inboxes;
 
@@ -128,10 +128,7 @@ pub fn spawn_receiver_tasks(
                             .process(batch_msg, net_clone.clone())
                             .await
                             .unwrap();
-                    }
-                    WrappedMessage::Triple(triple_gen_msg) => {
-                        debug!("Received triple_gen_msg");
-                        node_bind.process(triple_gen_msg).await.unwrap();
+                        node_bind.drain_batch_recon_output().await.unwrap();
                     }
                     _ => {
                         warn!("received invalid msg type");


### PR DESCRIPTION
Fixes for :
- Denial of Service via Unvalidated Secret Share IDs in MPC Protocols
- Missing Commitment Length Validation in Cryptographic Share Verification
- Out-of-Bounds Panic in AVSS Message Processing Causes Remote Denial of Service
- Send to self fix for batch recon
- State Inconsistency in Reliable Broadcast via Unverified Message Length
- Denial of Service via Unbounded Session Allocation in BatchReconNode
- Denial of Service in RanDouSha via Unvalidated Share Degrees
- Missing Share ID Validation in RanSha Enables Denial of Service
- Missing Masked Input Length Validation Causes MPC Cluster Denial of Service