### PR TITLE
Fixes

### DIFF
--- a/mpc/src/avss_mpc/input/input.rs
+++ b/mpc/src/avss_mpc/input/input.rs
@@ -394,6 +394,12 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>>
 
         // Verify Feldman commitments on received shares
         for share in &shares {
+            if share.feldmanshare.degree != self.t {
+                return Err(AvssInputError::InvalidInput(format!(
+                    "Invalid share degree from server {}",
+                    msg.sender_id
+                )));
+            }
             if !verify_feldman(share.clone()) {
                 return Err(AvssInputError::VerificationFailed(format!(
                     "Feldman verification failed for share from server {}",

--- a/mpc/src/avss_mpc/input/input.rs
+++ b/mpc/src/avss_mpc/input/input.rs
@@ -431,19 +431,30 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>>
             self.client_id, msg.sender_id
         );
 
-        let mut r_shares = vec![vec![]; input_len];
-        let mut masks = vec![];
-        let mut output = vec![];
-        // For Feldman shares, we need t+1 shares to reconstruct (degree t polynomial)
         if d.received_shares.len() >= self.t + 1 {
-            info!("Received enough shares to reconstruct");
-            for (_, r_share) in d.received_shares.iter() {
-                for i in 0..input_len {
-                    r_shares[i].push(r_share[i].clone());
+            let mut masks = vec![];
+            let mut output = vec![];
+            let mut consistent_groups: Vec<Option<Vec<FeldmanShamirShare<F, G>>>> =
+                vec![None; input_len];
+
+            for i in 0..input_len {
+                let mut by_commitment: HashMap<Vec<u8>, Vec<FeldmanShamirShare<F, G>>> =
+                    HashMap::new();
+                for (_, shares) in d.received_shares.iter() {
+                    let share = &shares[i];
+                    let mut key = Vec::new();
+                    share.commitments.serialize_compressed(&mut key)?;
+                    by_commitment.entry(key).or_default().push(share.clone());
+                }
+                match by_commitment.into_values().find(|g| g.len() >= self.t + 1) {
+                    Some(group) => consistent_groups[i] = Some(group),
+                    None => return Ok(()), // not enough consistent shares yet, wait for more
                 }
             }
-            for recon in r_shares {
-                let secret = FeldmanShamirShare::<F, G>::recover_secret(&recon, self.n, self.t)?;
+
+            info!("Received enough consistent shares to reconstruct");
+            for group in consistent_groups.into_iter().flatten() {
+                let secret = FeldmanShamirShare::<F, G>::recover_secret(&group, self.n, self.t)?;
                 masks.push(secret.1);
             }
 

--- a/mpc/src/avss_mpc/mod.rs
+++ b/mpc/src/avss_mpc/mod.rs
@@ -425,17 +425,6 @@ where
                     }
                 }
             }
-            AvssWrappedMessage::Mul(mul_message) => {
-                if sender_id != mul_message.sender {
-                    return Err(AvssMPCError::InvalidPartyId);
-                }
-                if mul_message.session_id.instance_id() != self.params.instance_id {
-                    return Err(AvssMPCError::InstanceIdError(
-                        mul_message.session_id.instance_id(),
-                    ));
-                }
-                self.mul_node.process(mul_message).await?
-            }
 
             AvssWrappedMessage::Input(_) => {
                 warn!("Incorrect message received at process function (Input)");

--- a/mpc/src/avss_mpc/mod.rs
+++ b/mpc/src/avss_mpc/mod.rs
@@ -28,13 +28,14 @@ use ark_std::rand::{
     Rng, SeedableRng,
 };
 use async_trait::async_trait;
-use bincode::ErrorKind;
+use bincode::{ErrorKind, Options};
 use serde::{Deserialize, Serialize};
 use std::{fmt, sync::Arc, time::Duration};
 use stoffelnet::network_utils::{ClientId, Network, NetworkError, PartyId};
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
+const MAX_MESSAGE_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 
 pub mod input;
 pub mod mul;
@@ -129,7 +130,11 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>>
         raw_msg: Vec<u8>,
         net: Arc<N>,
     ) -> Result<(), AvssMPCError> {
-        let wrapped: AvssWrappedMessage = bincode::deserialize(&raw_msg)?;
+        let wrapped: AvssWrappedMessage = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_MESSAGE_SIZE)
+            .deserialize(&raw_msg)?;
 
         match wrapped {
             AvssWrappedMessage::Input(input_msg) => {
@@ -389,7 +394,11 @@ where
         raw_msg: Vec<u8>,
         net: Arc<N>,
     ) -> Result<(), Self::Error> {
-        let wrapped: AvssWrappedMessage = bincode::deserialize(&raw_msg)?;
+        let wrapped: AvssWrappedMessage = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_MESSAGE_SIZE)
+            .deserialize(&raw_msg)?;
         match wrapped {
             AvssWrappedMessage::Rbc(rbc_msg) => {
                 if sender_id != rbc_msg.sender_id {

--- a/mpc/src/avss_mpc/mod.rs
+++ b/mpc/src/avss_mpc/mod.rs
@@ -446,15 +446,17 @@ where
                     }
                 }
             }
-
+            AvssWrappedMessage::Avss(_) => {
+                warn!("Incorrect message received at process function (Avss)");
+            }
+            AvssWrappedMessage::Mul(_) => {
+                warn!("Incorrect message received at process function (Input)");
+            }
             AvssWrappedMessage::Input(_) => {
                 warn!("Incorrect message received at process function (Input)");
             }
             AvssWrappedMessage::Output(_) => {
                 warn!("Incorrect message received at process function (Output)");
-            }
-            _ => {
-                warn!("Unknown session ID in AvssMPC");
             }
         }
 

--- a/mpc/src/avss_mpc/mod.rs
+++ b/mpc/src/avss_mpc/mod.rs
@@ -401,10 +401,7 @@ where
                     ));
                 }
                 if rbc_msg.msg_type.is_dealer_message() {
-                    let expected_dealer = match rbc_msg.session_id.calling_protocol() {
-                        Some(ProtocolType::Mul) => rbc_msg.session_id.round_id() as usize,
-                        _ => rbc_msg.session_id.sub_id() as usize,
-                    };
+                    let expected_dealer = rbc_msg.session_id.sub_id() as usize;
                     if rbc_msg.sender_id != expected_dealer {
                         warn!(
                             "Rejecting dealer message: 

--- a/mpc/src/avss_mpc/mod.rs
+++ b/mpc/src/avss_mpc/mod.rs
@@ -400,6 +400,21 @@ where
                         rbc_msg.session_id.instance_id(),
                     ));
                 }
+                if rbc_msg.msg_type.is_dealer_message() {
+                    let expected_dealer = match rbc_msg.session_id.calling_protocol() {
+                        Some(ProtocolType::Mul) => rbc_msg.session_id.round_id() as usize,
+                        _ => rbc_msg.session_id.sub_id() as usize,
+                    };
+                    if rbc_msg.sender_id != expected_dealer {
+                        warn!(
+                            "Rejecting dealer message: 
+                            sender {} is not expected dealer {} for session {:?}",
+                            rbc_msg.sender_id, expected_dealer, rbc_msg.session_id
+                        );
+                        return Err(AvssMPCError::InvalidPartyId);
+                    }
+                }
+
                 match rbc_msg.session_id.calling_protocol() {
                     Some(ProtocolType::Avss) => {
                         self.share_gen_avss.avss.rbc.process(rbc_msg, net).await?;

--- a/mpc/src/avss_mpc/mul/mod.rs
+++ b/mpc/src/avss_mpc/mul/mod.rs
@@ -49,6 +49,8 @@ pub enum MulError {
     Abort,
     #[error("Session id {0:?} does not exist in store")]
     ClearStoreError(AvssSessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -73,6 +73,14 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
 
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
+            let authenticated_sender = id.round_id() as usize;
+            if msg.sender != authenticated_sender {
+                warn!(
+                    "Dropping RBC output: inner sender {} does not match session round_id {}",
+                    msg.sender, authenticated_sender
+                );
+                continue;
+            }
 
             match self.open_mult_handler(msg).await {
                 Ok(()) => {}

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -3,6 +3,7 @@ use crate::avss_mpc::mul::{
 };
 use crate::avss_mpc::triple_gen::BeaverTriple;
 use crate::avss_mpc::{AvssSessionId, AvssWrappedMessage};
+use crate::common::share::avss::verify_feldman;
 use crate::common::share::feldman::FeldmanShamirShare;
 use crate::common::{share::ShareError, RBC};
 use crate::common::{ProtocolSessionId, SecretSharingScheme};
@@ -300,6 +301,18 @@ fn reconstruct_if_ready<F: FftField, G: CurveGroup<ScalarField = F>>(
                 warn!("Did not recieve the right number of shares to reconstruct using RBC (sent for a-x and for b-y)");
                 continue;
             }
+            // Verify Feldman commitments before accepting shares
+            let mut valid = true;
+            for i in 0..no_of_mul {
+                if !verify_feldman(a[i].clone()) || !verify_feldman(b[i].clone()) {
+                    valid = false;
+                    break;
+                }
+            }
+            if !valid {
+                continue;
+            }
+
             for i in 0..no_of_mul {
                 a_shares[i].push(a[i].clone());
                 b_shares[i].push(b[i].clone());

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -2,7 +2,7 @@ use crate::avss_mpc::mul::{
     MulError, MultMessage, MultProtocolState, MultStorage, ReconstructionMessage,
 };
 use crate::avss_mpc::triple_gen::BeaverTriple;
-use crate::avss_mpc::{AvssSessionId, AvssWrappedMessage};
+use crate::avss_mpc::{AvssSessionId, AvssWrappedMessage, MAX_MESSAGE_SIZE};
 use crate::common::share::avss::verify_feldman;
 use crate::common::share::feldman::FeldmanShamirShare;
 use crate::common::{share::ShareError, RBC};
@@ -10,6 +10,7 @@ use crate::common::{ProtocolSessionId, SecretSharingScheme};
 use ark_ec::CurveGroup;
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use bincode::Options;
 use itertools::izip;
 use std::{collections::HashMap, sync::Arc};
 use stoffelnet::network_utils::{Network, PartyId};
@@ -72,7 +73,11 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: MultMessage = bincode::deserialize(&output)?;
+            let msg: MultMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender != authenticated_sender {
                 warn!(

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -73,7 +73,7 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
 
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
-            let authenticated_sender = id.round_id() as usize;
+            let authenticated_sender = id.sub_id() as usize;
             if msg.sender != authenticated_sender {
                 warn!(
                     "Dropping RBC output: inner sender {} does not match session round_id {}",
@@ -144,7 +144,7 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
 
         let rbc_sessionid = AvssSessionId::new(
             session_id.calling_protocol().unwrap(),
-            AvssSessionId::pack_slot24(session_id.exec_id(), 0, self.id as u8),
+            AvssSessionId::pack_slot24(session_id.exec_id(), self.id as u8, 0),
             session_id.instance_id(),
         );
 

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -111,7 +111,7 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
         assert_eq!(session_id.round_id(), 0);
 
         let no_of_mul = x.len();
-        let storage_bind = self.get_or_create_mult_storage(session_id).await;
+        let storage_bind = self.get_or_create_mult_storage(session_id).await?;
         let mut storage = storage_bind.lock().await;
 
         storage.no_of_mul = Some(no_of_mul);
@@ -159,7 +159,7 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
     }
 
     pub async fn open_mult_handler(&self, msg: MultMessage) -> Result<(), MulError> {
-        let storage_bind = self.get_or_create_mult_storage(msg.session_id).await;
+        let storage_bind = self.get_or_create_mult_storage(msg.session_id).await?;
         let mut storage = storage_bind.lock().await;
         if storage.protocol_state == MultProtocolState::Finished {
             return Ok(());
@@ -196,16 +196,16 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
     pub async fn get_or_create_mult_storage(
         &self,
         session_id: AvssSessionId,
-    ) -> Arc<Mutex<MultStorage<F, G>>> {
+    ) -> Result<Arc<Mutex<MultStorage<F, G>>>, MulError> {
         let mut storage = self.mult_storage.lock().await;
-
-        // should never occur, since only exec ID changes for different runs
-        assert!(storage.len() <= 256);
-
-        storage
+        if storage.len() >= 256 && !storage.contains_key(&session_id) {
+            warn!("AVSS Mul session limit reached");
+            return Err(MulError::LimitError);
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(MultStorage::empty())))
-            .clone()
+            .clone())
     }
 
     pub async fn wait_for_result(

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -178,6 +178,25 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
         let open_message: ReconstructionMessage<F, G> =
             CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
 
+        // Validate degree and Feldman commitments before storing
+        for share in open_message
+            .a_sub_x
+            .iter()
+            .chain(open_message.b_sub_y.iter())
+        {
+            if share.feldmanshare.degree != self.t {
+                return Err(MulError::InvalidInput(format!(
+                    "Invalid share degree from sender {}",
+                    msg.sender
+                )));
+            }
+            if !verify_feldman(share.clone()) {
+                return Err(MulError::InvalidInput(format!(
+                    "Feldman verification failed for share from sender {}",
+                    msg.sender
+                )));
+            }
+        }
         storage
             .received_shares
             .insert(msg.sender, (open_message.a_sub_x, open_message.b_sub_y));
@@ -185,11 +204,6 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
         let _ = self.try_finalize_mul(msg.session_id, storage_bind).await?;
         info!("Multiplication completed at node {}", self.id);
 
-        Ok(())
-    }
-
-    pub async fn process(&mut self, message: MultMessage) -> Result<(), MulError> {
-        self.open_mult_handler(message).await?;
         Ok(())
     }
 

--- a/mpc/src/avss_mpc/mul/multiplication.rs
+++ b/mpc/src/avss_mpc/mul/multiplication.rs
@@ -86,6 +86,12 @@ impl<F: FftField, R: RBC<Id = AvssSessionId>, G: CurveGroup<ScalarField = F>> Mu
                 );
                 continue;
             }
+            if msg.session_id.exec_id() != id.exec_id()
+                || msg.session_id.instance_id() != id.instance_id()
+            {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
 
             match self.open_mult_handler(msg).await {
                 Ok(()) => {}

--- a/mpc/src/avss_mpc/output/output.rs
+++ b/mpc/src/avss_mpc/output/output.rs
@@ -112,8 +112,14 @@ impl<F: FftField, G: CurveGroup<ScalarField = F>> AvssOutputClient<F, G> {
             ));
         }
 
-        // 2. Verify Feldman commitments
+        // 2. Verify Feldman commitments and degree
         for share in &shares {
+            if share.feldmanshare.degree != self.t {
+                return Err(AvssOutputError::InvalidInput(format!(
+                    "Invalid share degree from server {}",
+                    msg.sender_id
+                )));
+            }
             if !verify_feldman(share.clone()) {
                 return Err(AvssOutputError::VerificationFailed(format!(
                     "Feldman verification failed for share from server {}",

--- a/mpc/src/avss_mpc/output/output.rs
+++ b/mpc/src/avss_mpc/output/output.rs
@@ -143,30 +143,40 @@ impl<F: FftField, G: CurveGroup<ScalarField = F>> AvssOutputClient<F, G> {
             share_store.insert(msg.sender_id, shares.clone());
             info!("Received Output share from server {}", msg.sender_id);
 
-            let mut r_shares = vec![vec![]; self.input_len];
-            // 5. For Feldman shares, we need t+1 shares to reconstruct
+            // 5. For Feldman shares, group by commitment fingerprint per output position,
+            //    reconstruct only from a consistent group of t+1 shares.
             if output_data.output.is_none() && share_store.len() >= self.t + 1 {
-                info!("Received enough shares to reconstruct output");
-                for (_, r_share) in share_store.iter() {
-                    for i in 0..self.input_len {
-                        r_shares[i].push(r_share[i].clone());
+                let mut consistent_groups: Vec<Option<Vec<FeldmanShamirShare<F, G>>>> =
+                    vec![None; self.input_len];
+
+                for i in 0..self.input_len {
+                    let mut by_commitment: HashMap<Vec<u8>, Vec<FeldmanShamirShare<F, G>>> =
+                        HashMap::new();
+                    for (_, shares) in share_store.iter() {
+                        let share = &shares[i];
+                        let mut key = Vec::new();
+                        if share.commitments.serialize_compressed(&mut key).is_err() {
+                            return false;
+                        }
+                        by_commitment.entry(key).or_default().push(share.clone());
+                    }
+                    match by_commitment.into_values().find(|g| g.len() >= self.t + 1) {
+                        Some(group) => consistent_groups[i] = Some(group),
+                        None => return false, // not enough consistent shares yet
                     }
                 }
 
+                info!("Received enough consistent shares to reconstruct output");
                 let mut output = Vec::new();
-
-                for output_elem in r_shares {
-                    let secret = match FeldmanShamirShare::<F, G>::recover_secret(
-                        &output_elem,
-                        self.n,
-                        self.t,
-                    ) {
-                        Ok(secret) => secret,
-                        Err(e) => {
-                            recovery_err = Some(e);
-                            return false;
-                        }
-                    };
+                for group in consistent_groups.into_iter().flatten() {
+                    let secret =
+                        match FeldmanShamirShare::<F, G>::recover_secret(&group, self.n, self.t) {
+                            Ok(secret) => secret,
+                            Err(e) => {
+                                recovery_err = Some(e);
+                                return false;
+                            }
+                        };
                     output.push(secret.1);
                 }
                 output_data.output = Some(output);

--- a/mpc/src/avss_mpc/share_gen/mod.rs
+++ b/mpc/src/avss_mpc/share_gen/mod.rs
@@ -36,6 +36,8 @@ pub enum RanShaAvssError {
     Abort,
     #[error("Party Id is out of bounds")]
     InvalidPartyId,
+    #[error("Store Limit")]
+    LimitError,
 }
 
 #[derive(Debug)]

--- a/mpc/src/avss_mpc/share_gen/share_gen_avss.rs
+++ b/mpc/src/avss_mpc/share_gen/share_gen_avss.rs
@@ -25,7 +25,7 @@ use tokio::{
     },
     time::{timeout, Duration},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone, Debug)]
 pub struct RanShaAvssNode<F: FftField, R: RBC, G: CurveGroup<ScalarField = F>> {
@@ -74,12 +74,16 @@ where
     pub async fn get_or_create_store(
         &mut self,
         session_id: AvssSessionId,
-    ) -> Arc<Mutex<RanShaAvssStore<F, C>>> {
+    ) -> Result<Arc<Mutex<RanShaAvssStore<F, C>>>, RanShaAvssError> {
         let mut storage = self.store.lock().await;
-        storage
+        if storage.len() >= 256 && !storage.contains_key(&session_id) {
+            warn!("RanShaAvss session limit reached");
+            return Err(RanShaAvssError::LimitError);
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(RanShaAvssStore::empty(self.n_parties))))
-            .clone()
+            .clone())
     }
 
     pub async fn wait_for_result(
@@ -142,7 +146,7 @@ where
                 let mut store = self.avss.shares.lock().await;
                 let avss_share = store.remove(&id).unwrap().unwrap();
                 drop(store);
-                let binding = self.get_or_create_store(session_id).await;
+                let binding = self.get_or_create_store(session_id).await?;
                 let mut ransha_storage = binding.lock().await;
                 let sender_id = id.sub_id();
                 if usize::from(sender_id) >= self.n_parties {
@@ -221,7 +225,7 @@ where
         }
 
         // Store results
-        let bind_store = self.get_or_create_store(session_id).await;
+        let bind_store = self.get_or_create_store(session_id).await?;
         let mut store = bind_store.lock().await;
 
         store.computed_r_shares = (0..n)

--- a/mpc/src/avss_mpc/triple_gen/mod.rs
+++ b/mpc/src/avss_mpc/triple_gen/mod.rs
@@ -47,6 +47,8 @@ pub enum TripleGenError {
     ResultAlreadyReceived(AvssSessionId),
     #[error("multiplication {0:?} did not complete in time")]
     Timeout(AvssSessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 /// Store for one triple session

--- a/mpc/src/avss_mpc/triple_gen/triple_gen.rs
+++ b/mpc/src/avss_mpc/triple_gen/triple_gen.rs
@@ -17,7 +17,7 @@ use tokio::sync::{
     mpsc::{self},
     Mutex,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone, Debug)]
 pub struct TripleGenNode<F: FftField, R: RBC, C: CurveGroup<ScalarField = F>> {
@@ -67,13 +67,18 @@ where
     async fn get_or_create_store(
         &mut self,
         sid: AvssSessionId,
-    ) -> Arc<Mutex<TripleGenStore<F, C>>> {
+    ) -> Result<Arc<Mutex<TripleGenStore<F, C>>>, TripleGenError> {
         let mut map = self.store.lock().await;
-        map.entry(sid)
+        if map.len() >= 256 && !map.contains_key(&sid) {
+            warn!("AVSS TripleGen session limit reached");
+            return Err(TripleGenError::LimitError);
+        }
+        Ok(map
+            .entry(sid)
             .or_insert(Arc::new(Mutex::new(TripleGenStore::empty(
                 2 * self.threshold + 1,
             ))))
-            .clone()
+            .clone())
     }
 
     pub async fn gen_triple<N, G>(
@@ -123,7 +128,7 @@ where
         }
 
         // Create store once
-        let store_ref = self.get_or_create_store(session_id).await;
+        let store_ref = self.get_or_create_store(session_id).await?;
         let xs: Vec<F> = (0..m).map(|i| F::from((i + 1) as u64)).collect();
 
         // === Step 3: collect dealer outputs, then lagrange-combine component-wise ===

--- a/mpc/src/avss_mpc/triple_gen/triple_gen.rs
+++ b/mpc/src/avss_mpc/triple_gen/triple_gen.rs
@@ -95,12 +95,12 @@ where
     {
         info!("party {} starting triple gen", self.id);
 
-        let t = self.threshold;
-        let m = 2 * t + 1;
-
         if a.len() != b.len() {
             return Err(TripleGenError::InvalidShareLength);
         }
+        let t = self.threshold;
+        let m = 2 * t + 1;
+
         let batch = a.len();
 
         // === Step 1: local products (vector) ===

--- a/mpc/src/common/rbc/rbc.rs
+++ b/mpc/src/common/rbc/rbc.rs
@@ -18,6 +18,8 @@ use tokio::{
 };
 use tracing::{debug, error, info, warn};
 
+const MAX_RBC_SESSIONS: usize = 1024;
+
 ///--------------------------Bracha RBC--------------------------
 ///
 /// Protocol works as follows(m is the message to broadcast) :
@@ -425,23 +427,28 @@ where
         Ok(())
     }
     async fn get_or_create_store(&self, session_id: Id) -> Option<Arc<Mutex<BrachaStore>>> {
-        // Step 1: get or create store
         let store_lock = {
             let mut store = self.store.lock().await;
+            if store.len() >= MAX_RBC_SESSIONS && !store.contains_key(&session_id) {
+                warn!(
+                    id = self.id,
+                    session_id = session_id.as_u64(),
+                    "Bracha session limit reached, dropping message"
+                );
+                return None;
+            }
             store
                 .entry(session_id)
                 .or_insert_with(|| Arc::new(Mutex::new(BrachaStore::default())))
                 .clone()
         };
 
-        // Step 2: check if already ended
         {
             let store_guard = store_lock.lock().await;
             if store_guard.ended {
                 return None;
             }
-        } // lock dropped here
-
+        }
         Some(store_lock)
     }
 }
@@ -1077,6 +1084,14 @@ impl<Id: ProtocolSessionId> Avid<Id> {
     async fn get_or_create_store(&self, session_id: Id) -> Option<Arc<Mutex<AvidStore>>> {
         let store_lock = {
             let mut store = self.store.lock().await;
+            if store.len() >= MAX_RBC_SESSIONS && !store.contains_key(&session_id) {
+                warn!(
+                    id = self.id,
+                    session_id = session_id.as_u64(),
+                    "Avid session limit reached, dropping message"
+                );
+                return None;
+            }
             store
                 .entry(session_id)
                 .or_insert_with(|| Arc::new(Mutex::new(AvidStore::default())))

--- a/mpc/src/common/rbc/rbc_store.rs
+++ b/mpc/src/common/rbc/rbc_store.rs
@@ -48,6 +48,18 @@ pub enum GenericMsgType {
     ABA(MsgTypeAba),
     Acs(MsgTypeAcs),
 }
+impl GenericMsgType {
+    pub fn is_dealer_message(&self) -> bool {
+        match self {
+            GenericMsgType::Bracha(MsgType::Init) => true,
+            GenericMsgType::Bracha(_) => false,
+            GenericMsgType::Avid(MsgTypeAvid::Send) => true,
+            GenericMsgType::Avid(_) => false,
+            GenericMsgType::ABA(_) => false,
+            GenericMsgType::Acs(_) => false,
+        }
+    }
+}
 // Implement Display for GenericMsgType
 impl fmt::Display for GenericMsgType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/mpc/src/common/share/avss.rs
+++ b/mpc/src/common/share/avss.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     rbc::RbcError,
-    share::{feldman::FeldmanShamirShare, ShareError},
+    share::{feldman::FeldmanShamirShare, shamir::Shamirshare, ShareError},
     ProtocolSessionId, RbcWrapFn, SecretSharingScheme, RBC,
 };
 use ark_ec::CurveGroup;
@@ -57,6 +57,7 @@ pub struct AvssMessage<Id: ProtocolSessionId> {
     pub sender_id: PartyId,
     pub session_id: Id,
     pub dealer_pk: Vec<u8>,
+    pub public_commitments: Vec<Vec<Vec<u8>>>,
     pub encrypted_shares: Vec<Vec<Vec<u8>>>,
 }
 
@@ -68,12 +69,14 @@ where
         sender: PartyId,
         session_id: Id,
         dealer_pk: Vec<u8>,
+        public_commitments: Vec<Vec<Vec<u8>>>,
         encrypted_shares: Vec<Vec<Vec<u8>>>,
     ) -> Self {
         Self {
             sender_id: sender,
             session_id,
             dealer_pk,
+            public_commitments,
             encrypted_shares,
         }
     }
@@ -276,13 +279,24 @@ where
                 kdf_from_point(&ss)
             })
             .collect();
+        let mut public_commitments: Vec<Vec<Vec<u8>>> = Vec::with_capacity(shares.len());
         let mut pt = Vec::new();
-        for x in shares {
+        for x in &shares {
             assert_eq!(x.len(), self.n_parties);
+            // commitments are identical across all parties for the same polynomial
+            let commitment_bytes = x[0]
+                .commitments
+                .iter()
+                .map(|c| {
+                    let mut b = Vec::new();
+                    c.serialize_compressed(&mut b).map(|_| b)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            public_commitments.push(commitment_bytes);
 
             for (i, share) in x.iter().enumerate() {
                 pt.clear();
-                share.serialize_compressed(&mut pt)?;
+                share.feldmanshare.serialize_compressed(&mut pt)?; // scalar only
                 encrypted[i].push(encrypt(keys[i].clone(), &pt, rng)?);
             }
         }
@@ -292,6 +306,7 @@ where
             sender_id: self.id,
             session_id: session_id,
             dealer_pk: pk_d_bytes,
+            public_commitments,
             encrypted_shares: encrypted,
         };
 
@@ -332,11 +347,30 @@ where
         let ss = pk_d.mul(self.sk_i);
         let key = kdf_from_point(&ss);
 
+        let all_commitments: Vec<Vec<G>> = msg
+            .public_commitments
+            .iter()
+            .map(|cs| {
+                cs.iter()
+                    .map(|b| G::deserialize_compressed(&b[..]))
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if cts.len() != all_commitments.len() {
+            return Err(AvssError::InvalidShareLength);
+        }
+
         let mut shares = Vec::with_capacity(cts.len());
-        for ct in cts {
+        for (ct, commitments) in cts.iter().zip(all_commitments.iter()) {
             let pt = decrypt(key.clone(), ct)?;
-            let share: FeldmanShamirShare<F, G> =
+            let shamirshare: Shamirshare<F> =
                 CanonicalDeserialize::deserialize_compressed(&pt[..])?;
+
+            let share = FeldmanShamirShare {
+                feldmanshare: shamirshare,
+                commitments: commitments.clone(),
+            };
 
             if !verify_feldman(share.clone()) {
                 return Err(AvssError::InvalidShare);

--- a/mpc/src/common/share/avss.rs
+++ b/mpc/src/common/share/avss.rs
@@ -7,7 +7,7 @@ use ark_ec::CurveGroup;
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::Rng;
-use bincode::ErrorKind;
+use bincode::{ErrorKind, Options};
 use chacha20poly1305::{
     aead::{Aead, KeyInit},
     ChaCha20Poly1305, Nonce,
@@ -21,6 +21,8 @@ use tokio::sync::{
     Mutex,
 };
 use tracing::info;
+
+const MAX_MESSAGE_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 
 #[derive(Debug, thiserror::Error)]
 pub enum AvssError {
@@ -225,8 +227,11 @@ where
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: AvssMessage<Id> = bincode::deserialize(&output)?;
-
+            let msg: AvssMessage<Id> = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             match self.process(msg).await {
                 Ok(()) => {}
                 Err(e) => {

--- a/mpc/src/common/share/avss.rs
+++ b/mpc/src/common/share/avss.rs
@@ -20,7 +20,7 @@ use tokio::sync::{
     mpsc::{self, Receiver, Sender},
     Mutex,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 const MAX_MESSAGE_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 
@@ -232,6 +232,12 @@ where
                 .allow_trailing_bytes()
                 .with_limit(MAX_MESSAGE_SIZE)
                 .deserialize(&output)?;
+
+            if msg.session_id != id {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
+
             match self.process(msg).await {
                 Ok(()) => {}
                 Err(e) => {

--- a/mpc/src/common/share/avss.rs
+++ b/mpc/src/common/share/avss.rs
@@ -54,7 +54,6 @@ pub enum AvssError {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AvssMessage<Id: ProtocolSessionId> {
-    pub sender_id: PartyId,
     pub session_id: Id,
     pub dealer_pk: Vec<u8>,
     pub public_commitments: Vec<Vec<Vec<u8>>>,
@@ -66,14 +65,12 @@ where
     Id: ProtocolSessionId,
 {
     pub fn new(
-        sender: PartyId,
         session_id: Id,
         dealer_pk: Vec<u8>,
         public_commitments: Vec<Vec<Vec<u8>>>,
         encrypted_shares: Vec<Vec<Vec<u8>>>,
     ) -> Self {
         Self {
-            sender_id: sender,
             session_id,
             dealer_pk,
             public_commitments,
@@ -303,7 +300,6 @@ where
 
         //Broadcast to servers
         let msg = AvssMessage {
-            sender_id: self.id,
             session_id: session_id,
             dealer_pk: pk_d_bytes,
             public_commitments,

--- a/mpc/src/honeybadger/double_share/double_share_generation.rs
+++ b/mpc/src/honeybadger/double_share/double_share_generation.rs
@@ -88,12 +88,16 @@ where
     pub async fn get_or_create_store(
         &mut self,
         session_id: SessionId,
-    ) -> Arc<Mutex<DouShaStorage<F>>> {
+    ) -> Result<Arc<Mutex<DouShaStorage<F>>>, DouShaError> {
         let mut storage = self.storage.lock().await;
-        storage
+        if storage.len() >= 256 && !storage.contains_key(&session_id) {
+            warn!("DouSha session limit reached");
+            return Err(DouShaError::LimitError);
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(DouShaStorage::empty(self.n_parties))))
-            .clone()
+            .clone())
     }
     pub async fn clear_store(&self, session_id: SessionId) -> bool {
         let mut store = self.storage.lock().await;
@@ -162,7 +166,7 @@ where
         }
 
         // Update the state of the protocol to Initialized.
-        let storage_access = self.get_or_create_store(session_id).await;
+        let storage_access = self.get_or_create_store(session_id).await?;
         let mut storage = storage_access.lock().await;
         storage.state = ProtocolState::Initialized;
         Ok(())
@@ -174,7 +178,7 @@ where
     ) -> Result<(), DouShaError> {
         let double_share: DoubleShamirShare<F> =
             CanonicalDeserialize::deserialize_compressed(recv_message.payload.as_slice())?;
-        let binding = self.get_or_create_store(recv_message.session_id).await;
+        let binding = self.get_or_create_store(recv_message.session_id).await?;
         let mut dousha_storage = binding.lock().await;
 
         if dousha_storage.state == ProtocolState::Finished {

--- a/mpc/src/honeybadger/double_share/mod.rs
+++ b/mpc/src/honeybadger/double_share/mod.rs
@@ -53,6 +53,8 @@ pub enum DouShaError {
     ResultAlreadyReceived(SessionId),
     #[error("multiplication {0:?} did not complete in time")]
     Timeout(SessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 #[derive(Clone, Debug, CanonicalSerialize, CanonicalDeserialize)]

--- a/mpc/src/honeybadger/fpmul/mod.rs
+++ b/mpc/src/honeybadger/fpmul/mod.rs
@@ -154,6 +154,8 @@ pub enum PRandError {
     Timeout(SessionId),
     #[error("Session id {0:?} does not exist in store")]
     ClearStoreError(SessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 /// Message sent in the Random Double Sharing protocol.
@@ -302,6 +304,8 @@ pub enum TruncPrError {
     Timeout(SessionId),
     #[error("Session id {0:?} does not exist in store")]
     ClearStoreError(SessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]

--- a/mpc/src/honeybadger/fpmul/prandbitd.rs
+++ b/mpc/src/honeybadger/fpmul/prandbitd.rs
@@ -22,7 +22,7 @@ use tokio::{
     sync::{mpsc::Receiver, Mutex},
     time::{timeout, Duration},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// Represents the shares stored by a player
 #[derive(Debug, Clone)]
@@ -234,7 +234,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
     {
         // Phase 0: Terminal fast-path
         {
-            let binding = self.get_or_create_store(session_id).await;
+            let binding = self.get_or_create_store(session_id).await?;
             let store = binding.lock().await;
 
             match calling_proto {
@@ -254,7 +254,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
 
         // Phase 1: Check readiness + decide what must be done
         let (batch_size, r_t_map, share_b_q, need_compute, need_open_start) = {
-            let binding = self.get_or_create_store(session_id).await;
+            let binding = self.get_or_create_store(session_id).await?;
             let store = binding.lock().await;
 
             let Some(batch_size) = store.batch_size else {
@@ -340,7 +340,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
         // ============================================================
         // Phase 3: Commit derived shares + PRandInt finish
         // ============================================================
-        let binding = self.get_or_create_store(session_id).await;
+        let binding = self.get_or_create_store(session_id).await?;
 
         let (int_sender, int_out) = {
             let mut store = binding.lock().await;
@@ -457,7 +457,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
         // Step 1: compute all maximal unqualified sets
         let tsets: Vec<Vec<usize>> = (0..self.n).combinations(self.t).collect();
 
-        let binding = self.get_or_create_store(session_id).await;
+        let binding = self.get_or_create_store(session_id).await?;
         let mut store = binding.lock().await;
         let my_tsets: Vec<Vec<usize>> = tsets
             .clone()
@@ -523,7 +523,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
             }
         };
 
-        let binding = self.get_or_create_store(msg.session_id).await;
+        let binding = self.get_or_create_store(msg.session_id).await?;
         let mut store = binding.lock().await;
 
         // Get or create entry for this tset
@@ -583,7 +583,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
             sid.instance_id(),
         );
 
-        let binding = self.get_or_create_store(session_id).await;
+        let binding = self.get_or_create_store(session_id).await?;
         let mut store = binding.lock().await;
         if store.state == PrandState::BitFinished {
             return Ok(());
@@ -608,14 +608,16 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
     pub async fn get_or_create_store(
         &mut self,
         session_id: SessionId,
-    ) -> Arc<Mutex<PRandBitDStore<F, G>>> {
+    ) -> Result<Arc<Mutex<PRandBitDStore<F, G>>>, PRandError> {
         let mut storage = self.store.lock().await;
 
-        // should never happen, since only exec ID changes for different runs
-        assert!(storage.len() <= 256);
-        storage
+        if storage.len() >= 256 && !storage.contains_key(&session_id) {
+            warn!("PRandBitD session limit reached");
+            return Err(PRandError::LimitError);
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(PRandBitDStore::empty())))
-            .clone()
+            .clone())
     }
 }

--- a/mpc/src/honeybadger/fpmul/prandbitd.rs
+++ b/mpc/src/honeybadger/fpmul/prandbitd.rs
@@ -418,7 +418,7 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
                 for (i, chunk) in share_rplusb.chunks(self.t + 1).enumerate() {
                     let session_id_batch = SessionId::new(
                         calling_proto,
-                        SessionId::pack_slot24(session_id.exec_id(), 0, i as u8),
+                        SessionId::pack_slot24(session_id.exec_id(), i as u8, 0),
                         session_id.instance_id(),
                     );
                     self.batch_recon
@@ -592,14 +592,14 @@ impl<F: PrimeField, G: PrimeField> PRandBitDNode<F, G> {
         // deserialize the field element from the payload
         let share_i_list: Vec<F> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
-        let round_id = sid.round_id();
-        if store.output_open.contains_key(&round_id) {
+        let dealer_id = sid.sub_id();
+        if store.output_open.contains_key(&dealer_id) {
             return Err(PRandError::Duplicate(format!(
                 "Already received for {}",
-                round_id
+                dealer_id
             )));
         }
-        store.output_open.insert(round_id, share_i_list);
+        store.output_open.insert(dealer_id, share_i_list);
         drop(store);
         self.try_finalize_bit(session_id, binding.clone()).await?;
         return Ok(());

--- a/mpc/src/honeybadger/fpmul/rand_bit.rs
+++ b/mpc/src/honeybadger/fpmul/rand_bit.rs
@@ -266,7 +266,7 @@ where
         for (i, chunk) in a_square_share.chunks(self.threshold + 1).enumerate() {
             let session_id_batch = SessionId::new(
                 session_id.calling_protocol().unwrap(),
-                SessionId::pack_slot24(session_id.exec_id(), 0, i as u8),
+                SessionId::pack_slot24(session_id.exec_id(), i as u8, 0),
                 session_id.instance_id(),
             );
             self.batch_recon
@@ -306,14 +306,14 @@ where
         }
 
         let open: Vec<F> = CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
-        let round_id = sid.round_id();
-        if storage.output_open.contains_key(&round_id) {
+        let dealer_id = sid.sub_id();
+        if storage.output_open.contains_key(&dealer_id) {
             return Err(RandBitError::Duplicate(format!(
                 "Already received for {}",
-                round_id
+                dealer_id
             )));
         }
-        storage.output_open.insert(round_id, open);
+        storage.output_open.insert(dealer_id, open);
         // If not initialized, data is stored but can't finalize yet.
         // init() will check for stored data and finalize if ready.
         if storage.a_share.is_none() {

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -73,7 +73,7 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let mut msg: TruncPrMessage = bincode::deserialize(&output)?;
-            let authenticated_sender = id.round_id() as usize;
+            let authenticated_sender = id.sub_id() as usize;
             if msg.sender_id != authenticated_sender {
                 warn!(
                     "Dropping RBC output: inner sender_id {} does not match session round_id {}",
@@ -270,7 +270,7 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
 
         let session_id = SessionId::new(
             calling_proto,
-            SessionId::pack_slot24(session.exec_id(), 0, self.id as u8),
+            SessionId::pack_slot24(session.exec_id(), self.id as u8, 0),
             session.instance_id(),
         );
         self.rbc

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -86,6 +86,12 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
                 );
                 continue;
             }
+            if msg.session_id.exec_id() != id.exec_id()
+                || msg.session_id.instance_id() != id.instance_id()
+            {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
             msg.sender_id = authenticated_sender;
             info!(
                 node_id = self.id,

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -72,7 +72,8 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: TruncPrMessage = bincode::deserialize(&output)?;
+            let mut msg: TruncPrMessage = bincode::deserialize(&output)?;
+            msg.sender_id = id.round_id() as usize;
 
             info!(
                 node_id = self.id,

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -5,11 +5,12 @@ use crate::{
             mod_pow_2_from_field, pow2_f, TruncPrError, TruncPrMessage, TruncPrStore, TruncState,
         },
         robust_interpolate::robust_interpolate::RobustShare,
-        SessionId, WrappedMessage,
+        SessionId, WrappedMessage, MAX_MESSAGE_SIZE,
     },
 };
 use ark_ff::PrimeField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use bincode::Options;
 use std::{collections::HashMap, sync::Arc};
 use stoffelnet::network_utils::Network;
 use tokio::{
@@ -72,7 +73,11 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
             };
 
             let output = self.rbc.get_store(id).await?;
-            let mut msg: TruncPrMessage = bincode::deserialize(&output)?;
+            let mut msg: TruncPrMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender_id != authenticated_sender {
                 warn!(

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -19,7 +19,7 @@ use tokio::{
     },
     time::{timeout, Duration},
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[derive(Debug, Clone)]
 pub struct TruncPrNode<F: PrimeField, R: RBC> {
@@ -73,8 +73,15 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let mut msg: TruncPrMessage = bincode::deserialize(&output)?;
-            msg.sender_id = id.round_id() as usize;
-
+            let authenticated_sender = id.round_id() as usize;
+            if msg.sender_id != authenticated_sender {
+                warn!(
+                    "Dropping RBC output: inner sender_id {} does not match session round_id {}",
+                    msg.sender_id, authenticated_sender
+                );
+                continue;
+            }
+            msg.sender_id = authenticated_sender;
             info!(
                 node_id = self.id,
                 "TruncPr received RBC output for open handler"

--- a/mpc/src/honeybadger/fpmul/truncpr.rs
+++ b/mpc/src/honeybadger/fpmul/truncpr.rs
@@ -96,15 +96,19 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
         Ok(())
     }
 
-    pub async fn get_or_create_store(&mut self, session: SessionId) -> Arc<Mutex<TruncPrStore<F>>> {
+    pub async fn get_or_create_store(
+        &mut self,
+        session: SessionId,
+    ) -> Result<Arc<Mutex<TruncPrStore<F>>>, TruncPrError> {
         let mut map = self.store.lock().await;
-
-        // should always hold, since only exec ID changes between different sessions
-        assert!(map.len() <= 256);
-
-        map.entry(session)
+        if map.len() >= 256 && !map.contains_key(&session) {
+            warn!("TruncPr session limit reached");
+            return Err(TruncPrError::LimitError);
+        }
+        Ok(map
+            .entry(session)
             .or_insert((|| Arc::new(Mutex::new(TruncPrStore::empty())))())
-            .clone()
+            .clone())
     }
 
     pub async fn clear_store(&self, session_id: SessionId) -> Result<(), TruncPrError> {
@@ -228,7 +232,7 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
             }
         };
 
-        let store = self.get_or_create_store(session).await; // k,m already set in store
+        let store = self.get_or_create_store(session).await?; // k,m already set in store
         let (r_dash, b) = {
             let mut s = store.lock().await;
             s.k = k;
@@ -294,7 +298,7 @@ impl<F: PrimeField, R: RBC<Id = SessionId>> TruncPrNode<F, R> {
             return Err(TruncPrError::SessionIdError(msg.session_id));
         }
 
-        let store = self.get_or_create_store(msg.session_id).await;
+        let store = self.get_or_create_store(msg.session_id).await?;
         {
             let mut s = store.lock().await;
 

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -416,6 +416,9 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputClient<F, R> {
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
         for share in &mut shares {
             share.id = msg.sender_id;
+            if share.degree != self.t {
+                return Err(InputError::InvalidInput("Invalid share degree".to_string()));
+            }
         }
         let mut d = self.client_data.lock().await;
 

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -438,6 +438,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputClient<F, R> {
 
         let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
+        if !shares.iter().all(|s| s.id == msg.sender_id) {
+            return Err(InputError::InvalidInput(
+                "Share ID does not match authenticated sender".into(),
+            ));
+        }
         for share in &mut shares {
             share.id = msg.sender_id;
             if share.degree != self.t {

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -17,6 +17,8 @@ use tokio::{
 };
 use tracing::info;
 
+const MAX_INPUT_ELEMENTS: u64 = 65_536;
+
 /// In the beginning of an MPC calculation, each node has to obtain a share of all clients' inputs.
 /// This happens via the mechanism described in Section 4.1 in the paper: given one random sharing
 /// per client input,
@@ -250,6 +252,15 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
         );
 
         let masked_inputs_as_shares: Vec<RobustShare<F>> = {
+            if payload.len() < 8 {
+                return Err(InputError::InvalidInput("Payload too short".to_string()));
+            }
+            let declared_len = u64::from_le_bytes(payload[..8].try_into().unwrap());
+            if declared_len > MAX_INPUT_ELEMENTS {
+                return Err(InputError::InvalidInput(
+                    "Declared input length exceeds maximum".to_string(),
+                ));
+            }
             let masked_inputs: Vec<F> =
                 ark_serialize::CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
             masked_inputs
@@ -412,6 +423,19 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputClient<F, R> {
         msg: InputMessage,
         net: Arc<N>,
     ) -> Result<(), InputError> {
+        let mut d = self.client_data.lock().await;
+        let input_len = d.inputs.len();
+
+        if msg.payload.len() < 8 {
+            return Err(InputError::InvalidInput("Payload too short".to_string()));
+        }
+        let declared_len = u64::from_le_bytes(msg.payload[..8].try_into().unwrap()) as usize;
+        if declared_len != input_len {
+            return Err(InputError::InvalidInput(
+                "Mismatch in input and share length".to_string(),
+            ));
+        }
+
         let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
         for share in &mut shares {
@@ -419,15 +443,6 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputClient<F, R> {
             if share.degree != self.t {
                 return Err(InputError::InvalidInput("Invalid share degree".to_string()));
             }
-        }
-        let mut d = self.client_data.lock().await;
-
-        let input_len = d.inputs.len();
-
-        if shares.len() != input_len {
-            return Err(InputError::InvalidInput(
-                "Mismatch in input and share length".to_string(),
-            ));
         }
 
         // happens if less than `n` messages were sufficient for reconstruction

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -15,7 +15,7 @@ use tokio::{
     },
     time::{timeout, Duration},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 const MAX_INPUT_ELEMENTS: u64 = 65_536;
 
@@ -147,7 +147,15 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let msg: InputMessage = bincode::deserialize(&output)?;
-            match self.input_handler(msg.sender_id, msg.payload).await {
+            let authenticated_sender = id.sub_id() as usize;
+            if msg.sender_id != authenticated_sender {
+                warn!(
+                    "Dropping RBC output: inner sender_id {} does not match session sub_id {}",
+                    msg.sender_id, authenticated_sender
+                );
+                continue;
+            }
+            match self.input_handler(authenticated_sender, msg.payload).await {
                 Ok(()) => {}
                 Err(e) => {
                     return Err(e);

--- a/mpc/src/honeybadger/input/input.rs
+++ b/mpc/src/honeybadger/input/input.rs
@@ -2,9 +2,10 @@ use crate::common::{ProtocolSessionId, SecretSharingScheme, RBC};
 use crate::honeybadger::input::InputError;
 use crate::honeybadger::input::InputMessage;
 use crate::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
-use crate::honeybadger::{ProtocolType, SessionId, WrappedMessage};
+use crate::honeybadger::{ProtocolType, SessionId, WrappedMessage, MAX_MESSAGE_SIZE};
 use ark_ff::FftField;
 use ark_serialize::CanonicalSerialize;
+use bincode::Options;
 use std::collections::HashMap;
 use std::sync::Arc;
 use stoffelnet::network_utils::{ClientId, Network, PartyId};
@@ -146,7 +147,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> InputServer<F, R> {
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: InputMessage = bincode::deserialize(&output)?;
+            let msg: InputMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender_id != authenticated_sender {
                 warn!(

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -514,6 +514,25 @@ where
                         rbc_msg.session_id.instance_id(),
                     ));
                 }
+                if rbc_msg.msg_type.is_dealer_message() {
+                    let expected_dealer = match rbc_msg.session_id.calling_protocol() {
+                        Some(
+                            ProtocolType::Mul
+                            | ProtocolType::FpDivConst
+                            | ProtocolType::FpMul
+                            | ProtocolType::RandBit,
+                        ) => rbc_msg.session_id.round_id() as usize,
+                        _ => rbc_msg.session_id.sub_id() as usize,
+                    };
+                    if rbc_msg.sender_id != expected_dealer {
+                        warn!(
+                            "Rejecting dealer message: sender {} is not expected dealer {} for session {:?}",
+                            rbc_msg.sender_id, expected_dealer, rbc_msg.session_id
+                        );
+                        return Err(HoneyBadgerError::InvalidPartyId);
+                    }
+                }
+
                 match rbc_msg.session_id.calling_protocol() {
                     Some(ProtocolType::Randousha) => {
                         self.preprocess

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -515,15 +515,7 @@ where
                     ));
                 }
                 if rbc_msg.msg_type.is_dealer_message() {
-                    let expected_dealer = match rbc_msg.session_id.calling_protocol() {
-                        Some(
-                            ProtocolType::Mul
-                            | ProtocolType::FpDivConst
-                            | ProtocolType::FpMul
-                            | ProtocolType::RandBit,
-                        ) => rbc_msg.session_id.round_id() as usize,
-                        _ => rbc_msg.session_id.sub_id() as usize,
-                    };
+                    let expected_dealer = rbc_msg.session_id.sub_id() as usize;
                     if rbc_msg.sender_id != expected_dealer {
                         warn!(
                             "Rejecting dealer message: sender {} is not expected dealer {} for session {:?}",
@@ -568,7 +560,7 @@ where
                             .await?;
                     }
                     Some(ProtocolType::FpMul) => {
-                        if rbc_msg.session_id.sub_id() == 0 {
+                        if rbc_msg.session_id.round_id() == 0 {
                             self.type_ops
                                 .fpmul
                                 .trunc_node
@@ -671,7 +663,7 @@ where
                             .await?
                     }
                     Some(ProtocolType::RandBit) => {
-                        if batch_msg.session_id.sub_id() == 0 {
+                        if batch_msg.session_id.round_id() == 0 {
                             self.preprocess
                                 .rand_bit
                                 .batch_recon

--- a/mpc/src/honeybadger/mod.rs
+++ b/mpc/src/honeybadger/mod.rs
@@ -68,7 +68,7 @@ use ark_ff::{FftField, PrimeField};
 use ark_std::rand::rngs::{OsRng, StdRng};
 use ark_std::rand::{Rng, SeedableRng};
 use async_trait::async_trait;
-use bincode::ErrorKind;
+use bincode::{ErrorKind, Options};
 use double_share_generation::DoubleShareNode;
 use ran_dou_sha::{RanDouShaError, RanDouShaNode};
 use robust_interpolate::robust_interpolate::RobustShare;
@@ -79,6 +79,10 @@ use thiserror::Error;
 use tokio::{sync::Mutex, time::Duration};
 use tracing::{info, warn};
 use triple_gen::triple_generation::TripleGenNode;
+
+/// Maximum number of bytes accepted from a single network message before deserialization.
+/// Rejects payloads that would cause multi-gigabyte allocations via a crafted length prefix.
+const MAX_MESSAGE_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
 
 #[derive(Error, Debug)]
 pub enum HoneyBadgerError {
@@ -177,7 +181,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> HoneyBadgerMPCClient<F, R> {
         raw_msg: Vec<u8>,
         net: Arc<N>,
     ) -> Result<(), HoneyBadgerError> {
-        let wrapped: WrappedMessage = bincode::deserialize(&raw_msg)?;
+        let wrapped: WrappedMessage = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_MESSAGE_SIZE)
+            .deserialize(&raw_msg)?;
 
         match wrapped {
             WrappedMessage::Input(input_msg) => {
@@ -490,7 +498,11 @@ where
         raw_msg: Vec<u8>,
         net: Arc<N>,
     ) -> Result<(), Self::Error> {
-        let wrapped: WrappedMessage = bincode::deserialize(&raw_msg)?;
+        let wrapped: WrappedMessage = bincode::DefaultOptions::new()
+            .with_fixint_encoding()
+            .allow_trailing_bytes()
+            .with_limit(MAX_MESSAGE_SIZE)
+            .deserialize(&raw_msg)?;
 
         match wrapped {
             WrappedMessage::Rbc(rbc_msg) => {

--- a/mpc/src/honeybadger/mul/mod.rs
+++ b/mpc/src/honeybadger/mul/mod.rs
@@ -105,6 +105,8 @@ pub enum MulError {
     Abort,
     #[error("Session id {0:?} does not exist in store")]
     ClearStoreError(SessionId),
+    #[error("Store Limit")]
+    LimitError,
 }
 
 /// Generic message for the multiplication protocol.

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -8,11 +8,12 @@ use crate::{
         },
         robust_interpolate::robust_interpolate::{Robust, RobustShare},
         triple_gen::ShamirBeaverTriple,
-        SessionId, WrappedMessage,
+        SessionId, WrappedMessage, MAX_MESSAGE_SIZE,
     },
 };
 use ark_ff::FftField;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+use bincode::Options;
 use itertools::izip;
 use std::{
     collections::HashMap,
@@ -184,7 +185,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: MultMessage = bincode::deserialize(&output)?;
+            let msg: MultMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender != authenticated_sender {
                 warn!(

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -118,6 +118,12 @@ fn reconstruct_rbc<F: FftField>(
         }
     }
     for i in 0..share_len {
+        let required = t + 1;
+        if a_shares[i].len() < required || b_shares[i].len() < required {
+            return Err(InterpolateError::InvalidInput(
+                "Insufficient valid shares for reconstruction".to_string(),
+            ));
+        }
         let a = RobustShare::recover_secret(&a_shares[i], n, t)?;
         let b = RobustShare::recover_secret(&b_shares[i], n, t)?;
 
@@ -179,6 +185,14 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
+            if msg.sender != id.round_id() as PartyId {
+                warn!(
+        "Dropping RBC output: inner sender {} does not match session's designated sender {}",
+        msg.sender,
+        id.round_id()
+    );
+                continue;
+            }
 
             match self
                 .open_mult_handler(msg.sender, msg.session_id, msg.payload)

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -200,6 +200,12 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
                 );
                 continue;
             }
+            if msg.session_id.exec_id() != id.exec_id()
+                || msg.session_id.instance_id() != id.instance_id()
+            {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
 
             match self
                 .open_mult_handler(authenticated_sender, msg.session_id, msg.payload)

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -185,17 +185,19 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
-            if msg.sender != id.round_id() as PartyId {
+            let authenticated_sender = id.round_id() as usize;
+            if msg.sender != authenticated_sender {
                 warn!(
-        "Dropping RBC output: inner sender {} does not match session's designated sender {}",
-        msg.sender,
-        id.round_id()
-    );
+                    "Dropping 
+                RBC output: inner sender {} does not match session's designated sender {}",
+                    msg.sender,
+                    id.round_id()
+                );
                 continue;
             }
 
             match self
-                .open_mult_handler(msg.sender, msg.session_id, msg.payload)
+                .open_mult_handler(authenticated_sender, msg.session_id, msg.payload)
                 .await
             {
                 Ok(()) => {}

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -185,13 +185,13 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
 
             let output = self.rbc.get_store(id).await?;
             let msg: MultMessage = bincode::deserialize(&output)?;
-            let authenticated_sender = id.round_id() as usize;
+            let authenticated_sender = id.sub_id() as usize;
             if msg.sender != authenticated_sender {
                 warn!(
                     "Dropping 
                 RBC output: inner sender {} does not match session's designated sender {}",
                     msg.sender,
-                    id.round_id()
+                    id.sub_id()
                 );
                 continue;
             }
@@ -374,7 +374,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             if !have_batch_recon1[i] {
                 let session_id1 = SessionId::new(
                     session_id.calling_protocol().unwrap(),
-                    SessionId::pack_slot24(session_id.exec_id(), 1, (2 * i) as u8),
+                    SessionId::pack_slot24(session_id.exec_id(), (2 * i) as u8, 1),
                     session_id.instance_id(),
                 );
                 // Execute batch reconstruction for a-x values
@@ -386,7 +386,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
             if !have_batch_recon2[i] {
                 let session_id2 = SessionId::new(
                     session_id.calling_protocol().unwrap(),
-                    SessionId::pack_slot24(session_id.exec_id(), 1, (2 * i + 1) as u8),
+                    SessionId::pack_slot24(session_id.exec_id(), (2 * i + 1) as u8, 1),
                     session_id.instance_id(),
                 );
                 // Execute batch reconstruction for b-y values
@@ -406,7 +406,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
 
             let sessionid = SessionId::new(
                 session_id.calling_protocol().unwrap(),
-                SessionId::pack_slot24(session_id.exec_id(), 2, self.id as u8),
+                SessionId::pack_slot24(session_id.exec_id(), self.id as u8, 2),
                 session_id.instance_id(),
             );
 
@@ -463,19 +463,19 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
         }
 
         // 2.
-        if sid.sub_id() == 1 {
+        if sid.round_id() == 1 {
             let open: Vec<F> = CanonicalDeserialize::deserialize_compressed(payload.as_slice())?;
-            let round_id = sid.round_id();
-            let (target_map, label) = if round_id % 2 == 0 {
+            let dealer_id = sid.sub_id();
+            let (target_map, label) = if dealer_id % 2 == 0 {
                 (&mut storage.output_open_mult1, "a-x")
             } else {
                 (&mut storage.output_open_mult2, "b-y")
             };
 
-            if target_map.contains_key(&round_id) {
+            if target_map.contains_key(&dealer_id) {
                 return Err(MulError::Duplicate(format!(
                     "Received duplicate of round {}",
-                    round_id
+                    dealer_id
                 )));
             }
 
@@ -484,11 +484,11 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
                 "Received opened {} values for session_id: {:?} and round {:?}",
                 label,
                 session_id,
-                round_id
+                dealer_id
             );
 
-            target_map.insert(round_id, open);
-        } else if sid.sub_id() == 2 {
+            target_map.insert(dealer_id, open);
+        } else if sid.round_id() == 2 {
             info!(
                 self_id = self.id,
                 "Received shares for reconstruction using RBC for session_id: {:?}", session_id
@@ -1043,12 +1043,12 @@ pub mod tests {
         {
             let session_id_a = SessionId::new(
                 ProtocolType::Mul,
-                SessionId::pack_slot24(session_id.exec_id(), 1, (2 * i) as u8),
+                SessionId::pack_slot24(session_id.exec_id(), (2 * i) as u8, 1),
                 session_id.instance_id(),
             );
             let session_id_b = SessionId::new(
                 ProtocolType::Mul,
-                SessionId::pack_slot24(session_id.exec_id(), 1, (2 * i + 1) as u8),
+                SessionId::pack_slot24(session_id.exec_id(), (2 * i + 1) as u8, 1),
                 session_id.instance_id(),
             );
 
@@ -1097,7 +1097,7 @@ pub mod tests {
 
                 let shared_session_id = SessionId::new(
                     ProtocolType::Mul,
-                    SessionId::pack_slot24(session_id.exec_id(), 2, mul_node.id as u8),
+                    SessionId::pack_slot24(session_id.exec_id(), mul_node.id as u8, 2),
                     session_id.instance_id(),
                 );
 

--- a/mpc/src/honeybadger/mul/multiplication.rs
+++ b/mpc/src/honeybadger/mul/multiplication.rs
@@ -287,7 +287,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
         let share_len = x.len() % (self.t + 1);
 
         // 1.
-        let storage_bind = self.get_or_create_mult_storage(session_id).await;
+        let storage_bind = self.get_or_create_mult_storage(session_id).await?;
         let mut storage = storage_bind.lock().await;
 
         // 2.
@@ -455,7 +455,7 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
         );
 
         // 1.
-        let storage_bind = self.get_or_create_mult_storage(session_id).await;
+        let storage_bind = self.get_or_create_mult_storage(session_id).await?;
         let mut storage = storage_bind.lock().await;
 
         if storage.protocol_state == MultProtocolState::Finished {
@@ -552,16 +552,17 @@ impl<F: FftField, R: RBC<Id = SessionId>> Multiply<F, R> {
     pub async fn get_or_create_mult_storage(
         &self,
         session_id: SessionId,
-    ) -> Arc<Mutex<MultStorage<F>>> {
+    ) -> Result<Arc<Mutex<MultStorage<F>>>, MulError> {
         let mut storage = self.mult_storage.lock().await;
 
-        // should never occur, since only exec ID changes for different runs
-        assert!(storage.len() <= 256);
-
-        storage
+        if storage.len() >= 256 && !storage.contains_key(&session_id) {
+            warn!("Mul session limit reached");
+            return Err(MulError::LimitError);
+        }
+        Ok(storage
             .entry(session_id)
             .or_insert(Arc::new(Mutex::new(MultStorage::empty())))
-            .clone()
+            .clone())
     }
 
     pub async fn wait_for_result(
@@ -839,7 +840,10 @@ pub mod tests {
         let start = Instant::now();
 
         loop {
-            let storage_bind = nodes[node_id].get_or_create_mult_storage(session_id).await;
+            let storage_bind = nodes[node_id]
+                .get_or_create_mult_storage(session_id)
+                .await
+                .unwrap();
             let storage = storage_bind.lock().await;
 
             let has_mult1_keys =
@@ -875,7 +879,10 @@ pub mod tests {
             .await
             .is_ok());
 
-        let storage_bind = nodes[node_id].get_or_create_mult_storage(session_id).await;
+        let storage_bind = nodes[node_id]
+            .get_or_create_mult_storage(session_id)
+            .await
+            .unwrap();
         let storage = storage_bind.lock().await;
 
         // openings via RBC should be there now
@@ -1006,7 +1013,10 @@ pub mod tests {
         // 4. Create node
         let mul_node = Multiply::<Fr, Avid<SessionId>>::new(node_id, n_parties, t).unwrap();
 
-        let storage_bind = mul_node.get_or_create_mult_storage(session_id).await;
+        let storage_bind = mul_node
+            .get_or_create_mult_storage(session_id)
+            .await
+            .unwrap();
         let mut storage = storage_bind.lock().await;
         storage.inputs = (
             x_inputs_per_node[node_id].clone(),

--- a/mpc/src/honeybadger/output/output.rs
+++ b/mpc/src/honeybadger/output/output.rs
@@ -117,6 +117,12 @@ impl<F: FftField> OutputClient<F> {
         let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;
 
+        if !shares.iter().all(|s| s.id == msg.sender_id) {
+            return Err(OutputError::InvalidInput(
+                "Share ID does not match authenticated sender".into(),
+            ));
+        }
+
         for share in &mut shares {
             share.id = msg.sender_id;
             if share.degree != self.t {

--- a/mpc/src/honeybadger/output/output.rs
+++ b/mpc/src/honeybadger/output/output.rs
@@ -104,6 +104,15 @@ impl<F: FftField> OutputClient<F> {
     /// 4. If the output has not been reconstructed yet and enough shares have been received,
     ///    attempt to reconstruct the output using robust interpolation.
     pub async fn output_handler(&mut self, msg: OutputMessage) -> Result<(), OutputError> {
+        if msg.payload.len() < 8 {
+            return Err(OutputError::InvalidInput("Payload too short".to_string()));
+        }
+        let declared_len = u64::from_le_bytes(msg.payload[..8].try_into().unwrap()) as usize;
+        if declared_len != self.input_len {
+            return Err(OutputError::InvalidInput(
+                "Mismatch in input and share length".to_string(),
+            ));
+        }
         // 1.
         let mut shares: Vec<RobustShare<F>> =
             ark_serialize::CanonicalDeserialize::deserialize_compressed(msg.payload.as_slice())?;

--- a/mpc/src/honeybadger/output/output.rs
+++ b/mpc/src/honeybadger/output/output.rs
@@ -110,6 +110,11 @@ impl<F: FftField> OutputClient<F> {
 
         for share in &mut shares {
             share.id = msg.sender_id;
+            if share.degree != self.t {
+                return Err(OutputError::InvalidInput(
+                    "Invalid share degree".to_string(),
+                ));
+            }
         }
         if shares.len() != self.input_len {
             return Err(OutputError::InvalidInput(

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -28,7 +28,7 @@ use tokio::sync::{
 use tokio::time::{timeout, Duration};
 
 use stoffelnet::network_utils::{Network, NetworkError, PartyId};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Error that occurs during the execution of the Random Double Share Error.
 #[derive(Debug, Error)]
@@ -207,7 +207,15 @@ where
 
             let output = self.rbc.get_store(id).await?;
             let mut msg: RanDouShaMessage = bincode::deserialize(&output)?;
-            msg.sender_id = id.sub_id() as usize;
+            let authenticated_sender = id.sub_id() as usize;
+            if msg.sender_id != authenticated_sender {
+                warn!(
+                    "Dropping RBC output: inner sender_id {} does not match session sub_id {}",
+                    msg.sender_id, authenticated_sender
+                );
+                continue;
+            }
+            msg.sender_id = authenticated_sender;
 
             match self.output_handler(msg).await {
                 Ok(()) => {}
@@ -322,7 +330,6 @@ where
 
         assert_eq!(session_id.sub_id(), 0);
 
-        // todo - should check sender.id == self?
         let vandermonde_matrix = make_vandermonde(self.n_parties, self.n_parties - 1)?;
         // Implementation of Step 1.
         let r_deg_t = apply_vandermonde(&vandermonde_matrix, &shares_deg_t)?;
@@ -507,7 +514,6 @@ where
             RanDouShaPayload::Output(ok) => ok,
         };
         info!("Node {} (session {}) - Starting output_handler for message from sender {}. Status: {}.", self.id, msg.session_id.as_u64(), msg.sender_id, output);
-        // todo - add randousha status so we can omit output_handler
         // abort randousha once received the abort message
         if !output {
             return Err(RanDouShaError::Abort);

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -8,13 +8,13 @@ use crate::{
     },
     honeybadger::{
         double_share::DoubleShamirShare, ran_dou_sha::messages::RanDouShaPayload,
-        robust_interpolate::InterpolateError, ProtocolType, SessionId, WrappedMessage,
+        robust_interpolate::InterpolateError, ProtocolType, SessionId, WrappedMessage, MAX_MESSAGE_SIZE,
     },
 };
 use ark_ff::FftField;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
 use ark_serialize::{CanonicalSerialize, SerializationError};
-use bincode::ErrorKind;
+use bincode::{ErrorKind, Options};
 use messages::{RanDouShaMessage, ReconstructionMessage};
 use std::{
     collections::{BTreeMap, HashMap},
@@ -206,7 +206,11 @@ where
             };
 
             let output = self.rbc.get_store(id).await?;
-            let mut msg: RanDouShaMessage = bincode::deserialize(&output)?;
+            let mut msg: RanDouShaMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender_id != authenticated_sender {
                 warn!(

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -206,7 +206,8 @@ where
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: RanDouShaMessage = bincode::deserialize(&output)?;
+            let mut msg: RanDouShaMessage = bincode::deserialize(&output)?;
+            msg.sender_id = id.sub_id() as usize;
 
             match self.output_handler(msg).await {
                 Ok(()) => {}

--- a/mpc/src/honeybadger/ran_dou_sha/mod.rs
+++ b/mpc/src/honeybadger/ran_dou_sha/mod.rs
@@ -8,7 +8,8 @@ use crate::{
     },
     honeybadger::{
         double_share::DoubleShamirShare, ran_dou_sha::messages::RanDouShaPayload,
-        robust_interpolate::InterpolateError, ProtocolType, SessionId, WrappedMessage, MAX_MESSAGE_SIZE,
+        robust_interpolate::InterpolateError, ProtocolType, SessionId, WrappedMessage,
+        MAX_MESSAGE_SIZE,
     },
 };
 use ark_ff::FftField;
@@ -219,6 +220,13 @@ where
                 );
                 continue;
             }
+            if msg.session_id.exec_id() != id.exec_id()
+                || msg.session_id.instance_id() != id.instance_id()
+            {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
+
             msg.sender_id = authenticated_sender;
 
             match self.output_handler(msg).await {

--- a/mpc/src/honeybadger/robust_interpolate/robust_interpolate.rs
+++ b/mpc/src/honeybadger/robust_interpolate/robust_interpolate.rs
@@ -96,6 +96,11 @@ impl<F: FftField> SecretSharingScheme<F> for RobustShare<F> {
         n: usize,
         t: usize,
     ) -> Result<(Vec<Self::SecretType>, Self::SecretType), InterpolateError> {
+        if shares.is_empty() {
+            return Err(InterpolateError::InvalidInput(
+                "Share slice is empty".to_string(),
+            ));
+        }
         let degree = shares[0].degree;
         if !shares.iter().all(|share| share.degree == degree) {
             return Err(InterpolateError::ShareError(ShareError::DegreeMismatch));

--- a/mpc/src/honeybadger/robust_interpolate/robust_interpolate.rs
+++ b/mpc/src/honeybadger/robust_interpolate/robust_interpolate.rs
@@ -96,6 +96,15 @@ impl<F: FftField> SecretSharingScheme<F> for RobustShare<F> {
         n: usize,
         t: usize,
     ) -> Result<(Vec<Self::SecretType>, Self::SecretType), InterpolateError> {
+        // n >= 3t + 1 is required for Byzantine fault tolerance
+        if n < 3 * t + 1 {
+            return Err(InterpolateError::InvalidInput(format!(
+                "n ({}) must be >= 3t + 1 ({}) for Byzantine fault tolerance",
+                n,
+                3 * t + 1
+            )));
+        }
+
         if shares.is_empty() {
             return Err(InterpolateError::InvalidInput(
                 "Share slice is empty".to_string(),

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 use stoffelnet::network_utils::{Network, PartyId};
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     common::{
@@ -79,8 +79,15 @@ where
 
             let output = self.rbc.get_store(id).await?;
             let mut msg: RanShaMessage = bincode::deserialize(&output)?;
-            msg.sender_id = id.sub_id() as usize;
-
+            let authenticated_sender = id.sub_id() as usize;
+            if msg.sender_id != authenticated_sender {
+                warn!(
+                    "Dropping RBC output: inner sender_id {} does not match session sub_id {}",
+                    msg.sender_id, authenticated_sender
+                );
+                continue;
+            }
+            msg.sender_id = authenticated_sender;
             match self.output_handler(msg).await {
                 Ok(()) => {}
                 Err(e) => {

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -93,6 +93,13 @@ where
                 );
                 continue;
             }
+            if msg.session_id.exec_id() != id.exec_id()
+                || msg.session_id.instance_id() != id.instance_id()
+            {
+                warn!("Dropping RBC output: inner session_id does not match RBC session metadata");
+                continue;
+            }
+
             msg.sender_id = authenticated_sender;
             match self.output_handler(msg).await {
                 Ok(()) => {}

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -2,12 +2,14 @@ use ark_ff::FftField;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::Rng;
+use bincode::Options;
 use std::{collections::HashMap, sync::Arc};
 use stoffelnet::network_utils::{Network, PartyId};
 use tokio::sync::Mutex;
 use tokio::time::{timeout, Duration};
 use tracing::{info, warn};
 
+use crate::honeybadger::MAX_MESSAGE_SIZE;
 use crate::{
     common::{
         share::{apply_vandermonde, make_vandermonde, ShareError},
@@ -78,7 +80,11 @@ where
             };
 
             let output = self.rbc.get_store(id).await?;
-            let mut msg: RanShaMessage = bincode::deserialize(&output)?;
+            let mut msg: RanShaMessage = bincode::DefaultOptions::new()
+                .with_fixint_encoding()
+                .allow_trailing_bytes()
+                .with_limit(MAX_MESSAGE_SIZE)
+                .deserialize(&output)?;
             let authenticated_sender = id.sub_id() as usize;
             if msg.sender_id != authenticated_sender {
                 warn!(

--- a/mpc/src/honeybadger/share_gen/share_gen.rs
+++ b/mpc/src/honeybadger/share_gen/share_gen.rs
@@ -78,7 +78,8 @@ where
             };
 
             let output = self.rbc.get_store(id).await?;
-            let msg: RanShaMessage = bincode::deserialize(&output)?;
+            let mut msg: RanShaMessage = bincode::deserialize(&output)?;
+            msg.sender_id = id.sub_id() as usize;
 
             match self.output_handler(msg).await {
                 Ok(()) => {}

--- a/mpc/tests/fpmul_test.rs
+++ b/mpc/tests/fpmul_test.rs
@@ -111,7 +111,7 @@ async fn test_prandbitd_end_to_end() {
     let domain_2 = Gf256Domain::new(n).unwrap();
 
     for node in &mut nodes {
-        let binding = node.get_or_create_store(session_id).await;
+        let binding = node.get_or_create_store(session_id).await.unwrap();
         let store = binding.lock().await;
         assert_eq!(
             store.share_b_2.len(),
@@ -140,7 +140,7 @@ async fn test_prandbitd_end_to_end() {
     let mut shares = vec![Vec::new(); batch_size];
 
     for node in &mut nodes {
-        let binding = node.get_or_create_store(session_id).await;
+        let binding = node.get_or_create_store(session_id).await.unwrap();
         {
             let store = binding.lock().await;
 
@@ -246,7 +246,7 @@ async fn test_prandbitd_r_reconstruction() {
     // === Step 1: Collect all r_T values from all nodes ===
     let mut all_r_t: HashMap<Vec<usize>, Vec<i64>> = HashMap::new();
     for node in &mut nodes {
-        let binding = node.get_or_create_store(session_id).await;
+        let binding = node.get_or_create_store(session_id).await.unwrap();
         let store = binding.lock().await;
         for (tset, val) in &store.r_t {
             // all parties that know this T should agree
@@ -284,7 +284,7 @@ async fn test_prandbitd_r_reconstruction() {
             vec![Vec::with_capacity(needed); batch_size];
 
         for &id in &combo {
-            let binding = nodes[id].get_or_create_store(session_id).await;
+            let binding = nodes[id].get_or_create_store(session_id).await.unwrap();
             let store = binding.lock().await;
             let share = store.share_r_q.clone().expect("missing share_r_q");
 
@@ -311,7 +311,7 @@ async fn test_prandbitd_r_reconstruction() {
 
     let mut shares_r2 = Vec::new();
     for node in &mut nodes {
-        let binding = node.get_or_create_store(session_id).await;
+        let binding = node.get_or_create_store(session_id).await.unwrap();
         let store = binding.lock().await;
         shares_r2.push((node.id, store.share_r_2.clone().expect("missing share_r_2")));
     }
@@ -340,7 +340,7 @@ async fn test_prandbitd_r_reconstruction() {
 
     // === Step 5: Per-node sanity: recompute share_r_2 from r_T values ===
     for node in &mut nodes {
-        let binding = node.get_or_create_store(session_id).await;
+        let binding = node.get_or_create_store(session_id).await.unwrap();
         let store = binding.lock().await;
         let tsets: Vec<Vec<usize>> = store.r_t.keys().cloned().collect();
         let poly_f2 = build_all_f_polys_2_8(n, tsets).unwrap();
@@ -437,7 +437,7 @@ async fn test_truncpr_end_to_end() {
     let mut shares = Vec::new();
 
     for node in &mut nodes {
-        let store = node.get_or_create_store(session_id).await;
+        let store = node.get_or_create_store(session_id).await.unwrap();
         let s = store.lock().await;
 
         assert!(s.share_d.is_some(), "Node {:?} missing share_d", node.id);

--- a/mpc/tests/prandbitd_test.rs
+++ b/mpc/tests/prandbitd_test.rs
@@ -78,7 +78,7 @@ async fn prandbitd_correctness_e2e() {
     let mut evaluation_points = Vec::new();
     let binary_domain = Gf256Domain::new(num_parties).unwrap();
     for node in &mut nodes {
-        let store = node.get_or_create_store(session_id.clone()).await;
+        let store = node.get_or_create_store(session_id.clone()).await.unwrap();
         let node_id = node.id;
         let store_guard = store.lock().await;
 

--- a/mpc/tests/rbc_test.rs
+++ b/mpc/tests/rbc_test.rs
@@ -271,7 +271,7 @@ mod tests {
             .await;
 
         // Allow time for propagation
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         for avid in &parties {
             let session_store = {

--- a/mpc/tests/utils/fpmul_utils.rs
+++ b/mpc/tests/utils/fpmul_utils.rs
@@ -53,10 +53,10 @@ where
                     }
                     WrappedMessage::Rbc(msg) => match msg.session_id.calling_protocol() {
                         Some(ProtocolType::FpMul) => {
-                            if msg.session_id.sub_id() == 2 {
+                            if msg.session_id.round_id() == 2 {
                                 node.mult_node.rbc.process(msg, net.clone()).await.unwrap();
                                 node.mult_node.drain_rbc_output().await.unwrap();
-                            } else if msg.session_id.sub_id() == 0 {
+                            } else if msg.session_id.round_id() == 0 {
                                 node.trunc_node.rbc.process(msg, net.clone()).await.unwrap();
                                 node.trunc_node.drain_rbc_output().await.unwrap();
                             } else {

--- a/mpc/tests/utils/rand_bit_utils.rs
+++ b/mpc/tests/utils/rand_bit_utils.rs
@@ -89,7 +89,7 @@ where
                 let wrapped: WrappedMessage = bincode::deserialize(&bytes).unwrap();
                 match wrapped {
                     WrappedMessage::BatchRecon(msg) => {
-                        if msg.session_id.sub_id() == 0 {
+                        if msg.session_id.round_id() == 0 {
                             let _ = node.batch_recon.process(msg, net.clone()).await;
                             node.drain_batch_recon_output().await.unwrap();
                         } else {


### PR DESCRIPTION
FIxes for the following issues:
- [STO-564: [VERIA-72] Permanent Denial of Service via Unvalidated Secret Share Poisoning
](https://linear.app/stoffel-labs/issue/STO-564/veria-72-permanent-denial-of-service-via-unvalidated-secret-share)
- [STO-566: [VERIA-63] Inconsistent Polynomial Commitments in AVSS Protocol Break MPC Integrity](https://linear.app/stoffel-labs/issue/STO-566/veria-63-inconsistent-polynomial-commitments-in-avss-protocol-break)
- [STO-570: [VERIA-53] Missing Feldman Commitment Verification Allows Undetected Share Corruption](https://linear.app/stoffel-labs/issue/STO-570/veria-53-missing-feldman-commitment-verification-allows-undetected)
- [STO-571: [VERIA-71] Reliable Broadcast Bypass in AVSS Multiplication Enables State Equivocation
](https://linear.app/stoffel-labs/issue/STO-571/veria-71-reliable-broadcast-bypass-in-avss-multiplication-enables)
- [STO-574: [VERIA-57] Unbounded Network Deserialization Leading to Memory Exhaustion](https://linear.app/stoffel-labs/issue/STO-574/veria-57-unbounded-network-deserialization-leading-to-memory)
- [STO-573: [VERIA-74] Remote Denial of Service via Malformed Payloads in Share Reconstruction
](https://linear.app/stoffel-labs/issue/STO-573/veria-74-remote-denial-of-service-via-malformed-payloads-in-share)
- [STO-567: [VERIA-54] Identity Binding Failure Enables Protocol Denial of Service and Preprocessing Corruption](https://linear.app/stoffel-labs/issue/STO-567/veria-54-identity-binding-failure-enables-protocol-denial-of-service)
- [STO-577: \[VERIA-67\] Sender Identity Spoofing and State Injection via Unbound Broadcast Payloads](https://linear.app/stoffel-labs/issue/STO-577/veria-67-sender-identity-spoofing-and-state-injection-via-unbound)
- [STO-578: \[VERIA-59\] Authentication Bypass via Missing Inner-Message Sender Verification](https://linear.app/stoffel-labs/issue/STO-578/veria-59-authentication-bypass-via-missing-inner-message-sender)
- [STO-568: \[VERIA-51\] Missing Dealer Authentication in Reliable Broadcast Allows Session Hijacking and Denial of Service](https://linear.app/stoffel-labs/issue/STO-568/veria-51-missing-dealer-authentication-in-reliable-broadcast-allows)
- [STO-585: \[VERIA-83\] Unbounded Bincode Deserialization Leading to Denial of Service in MPC Nodes](https://linear.app/stoffel-labs/issue/STO-585/veria-83-unbounded-bincode-deserialization-leading-to-denial-of)
- [STO-587: \[VERIA-82\] Session Metadata Validation Bypass in Multiplication Protocol](https://linear.app/stoffel-labs/issue/STO-587/veria-82-session-metadata-validation-bypass-in-multiplication-protocol)